### PR TITLE
improved installation command

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -72,7 +72,7 @@ __The following is for the impatient.__
 
 For full installation details (including on Microsoft Windows), please refer to INSTALL.txt. 
 
-       $ bash -s stable < <(curl -s https://raw.github.com/beefproject/beef/a6a7536e736e7788e12df91756a8f132ced24970/install-beef)
+       $ curl https://raw.github.com/beefproject/beef/a6a7536e/install-beef | bash -s stable
 
 
 Usage 


### PR DESCRIPTION
updated the installation command:
- reversed notation to prevent `curl -s` and hiding errors,
- shortened the commit sha1, still usable but easier to see whole command.
