### PR TITLE
Remove Thin 'Server' response header

### DIFF
--- a/core/main/server.rb
+++ b/core/main/server.rb
@@ -4,6 +4,10 @@
 # See the file 'doc/COPYING' for copying permission
 #
 
+# Remove Thin 'Server' response header
+Thin.send :remove_const, :SERVER
+Thin::SERVER = nil
+
 module BeEF
   module Core
 


### PR DESCRIPTION
By default Thin sends the full Thin version in the response headers. For example:

```
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Content-Length: 1027
Connection: keep-alive
Server: thin 1.5.0 codename Knife
```

As BeEF is designed for penetration testers it would be nice to remove the advertisement of the server version in the response headers. An example of headers following this commit looks like:

```
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Content-Length: 1027
Connection: keep-alive
```

I am new to BeEF and there are a number of places and ways this response header could be removed. I decided to go for the simplest. If this isn't inline with the BeEF way of doing things, let me know, and I will amend my commit.
