### PR TITLE
Add 'bind_raw' to asset handler

### DIFF
--- a/core/bootstrap.rb
+++ b/core/bootstrap.rb
@@ -25,6 +25,7 @@ require 'core/main/handlers/browserdetails'
 # @note Include the network stack
 require 'core/main/network_stack/handlers/dynamicreconstruction'
 require 'core/main/network_stack/handlers/redirector'
+require 'core/main/network_stack/handlers/raw'
 require 'core/main/network_stack/assethandler'
 require 'core/main/network_stack/api'
 

--- a/core/main/network_stack/assethandler.rb
+++ b/core/main/network_stack/assethandler.rb
@@ -38,6 +38,24 @@ module Handlers
       url
     end
 
+    # Binds raw HTTP to a mount point
+    # @param [Integer] status HTTP status code to return
+    # @param [String] headers HTTP headers as a JSON string to return
+    # @param [String] body HTTP body to return
+    # @param [String] path URL path to mount the asset to TODO (can be nil for random path)
+    # @todo @param [Integer] count The amount of times the asset can be accessed before being automatically unbinded (-1 = unlimited)
+    def bind_raw(status, header, body, path=nil, count=-1)
+      url = build_url(path,nil)
+      @allocations[url] = {}
+      @http_server.mount(
+        url,
+        BeEF::Core::NetworkStack::Handlers::Raw.new(status, header, body)
+      )
+      @http_server.remap
+      print_info "Raw HTTP bound to url [" + url + "]"
+      url
+    end
+
     # Binds a file to a mount point
     # @param [String] file File path to asset
     # @param [String] path URL path to mount the asset to (can be nil for random path)

--- a/core/main/network_stack/handlers/raw.rb
+++ b/core/main/network_stack/handlers/raw.rb
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+module BeEF
+  module Core
+    module NetworkStack
+      module Handlers
+
+        class Raw
+
+	        def initialize(status, header={}, body)
+	        	@status  = status
+	                @header  = header
+	                @body    = body
+	        end
+
+	        def call(env)
+	            [@status, @header, @body]
+	        end
+
+	        private
+
+	        @request
+
+	        @response
+
+	    end
+	end
+end
+end
+end

--- a/modules/debug/test_http_bind_raw/command.js
+++ b/modules/debug/test_http_bind_raw/command.js
@@ -1,0 +1,11 @@
+//
+// Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+
+	beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=mounted to /beef');
+
+});

--- a/modules/debug/test_http_bind_raw/config.yaml
+++ b/modules/debug/test_http_bind_raw/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        test_http_bind_raw:
+            enable: true
+            category: "Debug"
+            name: "Test HTTP Bind Raw"
+            description: "Test the HTTP 'bind_raw' handler."
+            authors: ["bcoles"]
+            target:
+                 working: ["All"]

--- a/modules/debug/test_http_bind_raw/module.rb
+++ b/modules/debug/test_http_bind_raw/module.rb
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Test_http_bind_raw < BeEF::Core::Command
+
+  def pre_send
+    configuration = BeEF::Core::Configuration.instance
+    xss_hook_url = "http://#{configuration.get("beef.http.host")}:#{configuration.get("beef.http.port")}/demos/basic.html"
+    BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.bind_raw('200', {'Content-Type'=>'text/html','beef'=>xss_hook_url}, 'hello world!', '/beef', -1)
+  end
+
+  def post_execute
+    content = {}
+    content['Result'] = @datastore['result']
+    save content
+  end
+
+end

--- a/modules/debug/test_http_redirect/command.js
+++ b/modules/debug/test_http_redirect/command.js
@@ -1,0 +1,11 @@
+//
+// Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+
+	beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=mounted to /redirect');
+
+});

--- a/modules/debug/test_http_redirect/config.yaml
+++ b/modules/debug/test_http_redirect/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        test_http_redirect:
+            enable: true
+            category: "Debug"
+            name: "Test HTTP Redirect"
+            description: "Test the HTTP 'redirect' handler."
+            authors: ["bcoles"]
+            target:
+                 working: ["All"]

--- a/modules/debug/test_http_redirect/module.rb
+++ b/modules/debug/test_http_redirect/module.rb
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2006-2013 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Test_http_redirect < BeEF::Core::Command
+
+  def pre_send
+    BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.bind_redirect('http://beefproject.com', '/redirect')
+  end
+
+  def post_execute
+    content = {}
+    content['Result'] = @datastore['result']
+    save content
+  end
+
+end


### PR DESCRIPTION
Allows modules to use `BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.bind_raw(status, header, body)` to return HTTP/HTML at a custom mount point.

Part of issue #101
