### PR TITLE
Add .rvmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/msf-test
 custom-config.yaml
 .DS_Store
 .gitignore
+.rvmrc


### PR DESCRIPTION
I use RVM for my Rubies management and commonly drop a .rvmrc file into my beef repo so when I change into that directory it will automagically put me in the right BeEF environment with all the necessary gems.
# To Create

rvm use --create --rvmrc 1.9.3-p374@beef
# To Use

claudijd@macbookpro [code] $ cd beef/
Using: /Users/jclaudius/.rvm/gems/ruby-1.9.3-p374@beef

Anyways, I figured there were enough RVM users out their that this might make it easier for them to dev on BeEF without having that pesky .rvmrc hanging around in their git status results.

Hope this is helpful!

@claudijd
