### PR TITLE
Enhancements to Mass Mailer

### DIFF
--- a/extensions/social_engineering/config.yaml
+++ b/extensions/social_engineering/config.yaml
@@ -23,7 +23,6 @@ beef:
                 helo: "gmail.com" # this is usually the domain name
                 auth: "youruser@gmail.com"
                 password: "yourpass"
-                from: "fromemail@gmail.com"
                 # available templates
                 templates:
                     default:

--- a/extensions/social_engineering/rest/socialengineering.rb
+++ b/extensions/social_engineering/rest/socialengineering.rb
@@ -70,6 +70,7 @@ module BeEF
         #    "template": "default",
         #    "subject": "Hi from BeEF",
         #    "fromname": "BeEF",
+        #    "fromaddr": "beef@beef.com",
         #    "link": "http://www.microsoft.com/security/online-privacy/phishing-symptoms.aspx",
         #    "linktext": "http://beefproject.com",
         #    "recipients": [{
@@ -85,10 +86,11 @@ module BeEF
             template = body["template"]
             subject = body["subject"]
             fromname = body["fromname"]
+            fromaddr = body["fromaddr"]
             link = body["link"]
             linktext = body["linktext"]
 
-            if template.nil? || subject.nil? || fromname.nil? || link.nil? || linktext.nil?
+            if template.nil? || subject.nil? || fromaddr.nil? || fromname.nil? || link.nil? || linktext.nil?
               print_error "All parameters are mandatory."
               halt 401
             end
@@ -113,7 +115,7 @@ module BeEF
 
           begin
             mass_mailer = BeEF::Extension::SocialEngineering::MassMailer.instance
-            mass_mailer.send_email(template, fromname, subject, link, linktext, recipients)
+            mass_mailer.send_email(template, fromname, fromaddr, subject, link, linktext, recipients)
           rescue Exception => e
             print_error "Invalid mailer configuration"
             error 400


### PR DESCRIPTION
Hello Beef,

I've made a few enhancements (hopefully) to the beef mass mailer that I'd like to share:
- Authentication credentials can now be supplied independently of the from address making it easier to spoof mail addresses
- Fixed bug in debugging that would report errors as coming from the website cloner configuration
- Added extra debugging to make it easier to see when you have a problem with your mailer config or templates.
- Moved the from address field into the json requests so that you can send emails from more than one source in a single session.

I've tested the changes with gmail and my local ISP's relay and everything looks like it's still working.

Can you check it out and let me know what you think?

Cheers,
George
