### PR TITLE
Abort on error

### DIFF
--- a/install-beef
+++ b/install-beef
@@ -5,6 +5,8 @@
 # See the file 'doc/COPYING' for copying permission
 #
 
+set -e
+
 clear
 echo "======================================"
 echo "          BeEF Installer   "


### PR DESCRIPTION
On a (debian) system without sudo, lots of messages rush by, and it's not obvious was fails.
With this change, the log looks like:

```
$ bash install-beef
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
======================================
           BeEF Installer
======================================

CAUTION: This installation script will install a number of BeEF dependencies including the Ruby-RVM environemnt and it's dependencies.

In rare cases, this may lead to unexpected behaviour or package conflicts on some systems.

Are you sure you wish to continue (Y/n)?

Detecting OS..
Debian/Ubuntu Detected
Installing Prerequisite Packages..
install-beef: line 74: sudo: command not found
```

which is far more informative.
