### PR TITLE
Use a pipe instead of a fifo during installation

### DIFF
--- a/install-beef
+++ b/install-beef
@@ -76,7 +76,7 @@ if [ "$Distro" == "Debian" ]; then
 
 sudo apt-get install build-essential openssl libreadline6 libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev libncurses5-dev automake libtool bison subversion
 
-bash < <(curl -sk https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
+curl -sk https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash
 
 echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"' >> ~/.bashrc
 


### PR DESCRIPTION
bash's anonymous fifos are only available if devfs is mounted.
On a system without /dev mounted (which is perfectly reasonable for a locked-down security testing machine), installing beef fails with (after applying #923)

```
install-beef: line 81: /dev/fd/62: No such file or directory
```

This commit fixes and lets the installation run through.
