### PR TITLE
Update twitter require version 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "msfrpc-client"
 gem "rubyzip", "~> 1.0.0"
 
 # notifications
-gem "twitter"
+gem "twitter", ">= 5.0.0"
 
 if ENV['BEEF_TEST']
 # for running unit tests

--- a/extensions/notifications/channels/tweet.rb
+++ b/extensions/notifications/channels/tweet.rb
@@ -21,7 +21,7 @@ module Channels
       @config = BeEF::Core::Configuration.instance
 
       # configure the Twitter client
-      Twitter.configure do |config|
+      client = Twitter::REST::Client.new do |config|
         config.consumer_key       = @config.get('beef.extension.notifications.twitter.consumer_key')
         config.consumer_secret    = @config.get('beef.extension.notifications.twitter.consumer_secret')
         config.oauth_token    = @config.get('beef.extension.notifications.twitter.oauth_token')
@@ -29,7 +29,7 @@ module Channels
       end
 
       begin
-        Twitter.direct_message_create(username, message)
+        client.direct_message_create(username, message)
       rescue
         print "Twitter send failed, verify tokens have Read/Write/DM acceess..\n"
       end


### PR DESCRIPTION
The latest Twitter gem has removed the Twitter.configure method breaking Twitter notifications for anyone who installs BeEF from scratch and runs bundle install as they will get version 5.0.0 of the gem.

This pull request fixes the problem by requiring 5.0.0 in the Gemfile and making the channels/tweet.rb compatible with the new 5.0.0 syntax.

Alternatively, we could force the requirement for an older version of the Twitter gem, this doesn't seem the right thing to do though, forcing old versions of software when it's a simple fix to move forward.

This patch does not have any error handling for an existing checkout of BeEF updated to this revision but without having run bundle to get version 5 of the gem. This will cause the following:

NameError: uninitialized constant Twitter::REST

I haven't had time to implement it but we should perhaps rescue that error and display a message advising to run bundle?
