### PR TITLE
use request.port in BeEF::Core::Handlers::Modules::BeEFJS.build_beefjs!

### DIFF
--- a/core/main/handlers/hookedbrowsers.rb
+++ b/core/main/handlers/hookedbrowsers.rb
@@ -47,7 +47,7 @@ module Handlers
         # @note generate the instructions to hook the browser
         host_name = request.host
         (print_error "Invalid host name";return) if not BeEF::Filters.is_valid_hostname?(host_name)
-        build_beefjs!(host_name)
+        build_beefjs!(host_name, request.port)
 
       # @note is a known browser so send instructions 
       else       

--- a/core/main/handlers/modules/beefjs.rb
+++ b/core/main/handlers/modules/beefjs.rb
@@ -12,8 +12,9 @@ module BeEF
         module BeEFJS
 
           # Builds the default beefjs library (all default components of the library).
-          # @param [Object] req_host The request object
-          def build_beefjs!(req_host)
+          # @param [String] req_host Host name in the request object
+          # @param [Fixnum] req_port Port number in the request object
+          def build_beefjs!(req_host, req_port)
             config = BeEF::Core::Configuration.instance
             # @note set up values required to construct beefjs
             beef_js = ''
@@ -83,6 +84,9 @@ module BeEF
             # @note set the hook file path and BeEF's cookie name
             hook_session_config['hook_file'] = config.get("beef.http.hook_file")
             hook_session_config['hook_session_name'] = config.get("beef.http.hook_session_name")
+
+            # @note use port from the request object
+            hook_session_config['beef_port'] = req_port
 
             # @note if http_port <> public_port in config ini, use the public_port
             unless hook_session_config['beef_public_port'].nil?


### PR DESCRIPTION
hook.js will be able to find the beef server behind a reverse proxy
using the port in the request instead of from the config

Not sure if this will break any other use case.
