### PR TITLE
Add support for MaxMind GeoIP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "msfrpc-client"        # Metasploit Integration extension
 gem "rubyzip", ">= 1.0.0"
 gem "rubydns"              # DNS extension
 gem "sourcify"
+gem "geoip"                # geolocation support
 
 # For running unit tests
 if ENV['BEEF_TEST']

--- a/config.yaml
+++ b/config.yaml
@@ -103,6 +103,13 @@ beef:
 
     crypto_default_value_length: 80
 
+    # IP Geolocation
+    # Requires MaxMind database
+    # curl -O http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+    geoip:
+      enable: false
+      database: '/opt/GeoIP/GeoLiteCity.dat'
+
     # You may override default extension configuration parameters here
     extension:
         requester:

--- a/extensions/admin_ui/controllers/modules/modules.rb
+++ b/extensions/admin_ui/controllers/modules/modules.rb
@@ -95,6 +95,20 @@ class Modules < BeEF::Extension::AdminUI::HttpController
         ['Browser Components', 'Session Cookies',    'hasSessionCookies'],
         ['Browser Components', 'Persistent Cookies', 'hasPersistentCookies'],
 
+        # Geolocation
+        ['Location', 'City',          'LocationCity'],
+        ['Location', 'Country',       'LocationCountry'],
+        ['Location', 'CountryCode2',  'LocationCountryCode2'],
+        ['Location', 'CountryCode3',  'LocationCountryCode3'],
+        ['Location', 'Continent',     'LocationContinentCode'],
+        ['Location', 'Post Code',     'LocationPostCode'],
+        ['Location', 'Latitude',      'LocationLatitude'],
+        ['Location', 'Longitude',     'LocationLongitude'],
+        ['Location', 'DMA Code',      'LocationDMACode'],
+        ['Location', 'Area Code',     'LocationAreaCode'],
+        ['Location', 'Timezone',      'LocationTimezone'],
+        ['Location', 'Region',        'LocationRegionName'],
+
         # Hooked Page
         ['Hooked Page', 'Page Title',    'PageTitle'],
         ['Hooked Page', 'Page URI',      'PageURI'],


### PR DESCRIPTION
- Disabled by default.
- The user must download the database from MaxMInd. It is not distributed with BeEF.
- No geolocation data is returned for LAN IP addresses.
