### PR TITLE
Support pulling the server version through the REST API

### DIFF
--- a/core/main/rest/handlers/server.rb
+++ b/core/main/rest/handlers/server.rb
@@ -35,6 +35,10 @@ module BeEF
             error 400
           end
         end
+
+        get '/version' do
+          { 'version' => config.get('beef.version') }.to_json
+        end
       end
     end
   end


### PR DESCRIPTION
This PR add support to the REST API for retrieving the servers version.  This will be useful for third party tools that are trying to integrate with BeEF and need features only available in newer version.

Example test output using curl:

```
[git :S beef:rest-api-version] [15:34:34 steiner beef]% curl -i "http://localhost:3000/api/server/version"
HTTP/1.1 401 Unauthorized
Content-Type: text/html; charset=UTF-8
Server: Apache/2.2.3 (CentOS)
Content-Length: 0
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Connection: keep-alive

[git :S beef:rest-api-version] [15:34:37 steiner beef]% curl -i "http://localhost:3000/api/server/version?token=176d66d7658a6be149fe5089790ba196aa77c50e"
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Server: Apache/2.2.3 (CentOS)
Pragma: no-cache
Cache-Control: no-cache
Expires: 0
Content-Length: 27
X-Content-Type-Options: nosniff
Connection: keep-alive

{"version":"0.4.5.1-alpha"}
[git :S beef:rest-api-version] [15:34:57 steiner beef]%
```
