### PR TITLE
Make curl follow redirects on github

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -51,8 +51,8 @@ Installation
       - XCode: provides the sqlite support BeEF needs
       
       - Ruby 1.9
-      	To install RVM and Ruby 1.9.3 on Mac OS:  
-      	$ bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer) source ~/.bash_profile 
+      	To install RVM and Ruby 1.9.3 on Mac OS:
+      	$ bash -s stable < <(curl -Ls https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer) source ~/.bash_profile
       	$ rvm install 1.9.3-p484
 		$ rvm use 1.9.3
       

--- a/README
+++ b/README
@@ -48,7 +48,7 @@ __The following is for the impatient.__
 For full installation details (including on Microsoft Windows), please refer to INSTALL.txt.
 We also have a Wiki page at https://github.com/beefproject/beef/wiki/Installation
 
-   $ bash -s stable < <(curl -s https://raw.github.com/beefproject/beef/a6a7536e736e7788e12df91756a8f132ced24970/install-beef)
+   $ bash -s stable < <(curl -Ls https://raw.github.com/beefproject/beef/a6a7536e736e7788e12df91756a8f132ced24970/install-beef)
 
 
 Usage 

--- a/README.mkd
+++ b/README.mkd
@@ -48,7 +48,7 @@ __The following is for the impatient.__
 For full installation details (including on Microsoft Windows), please refer to INSTALL.txt.
 We also have a Wiki page at https://github.com/beefproject/beef/wiki/Installation
 
-       $ curl https://raw.github.com/beefproject/beef/a6a7536e/install-beef | bash -s stable
+       $ curl -L https://raw.github.com/beefproject/beef/a6a7536e/install-beef | bash -s stable
 
 
 Usage 

--- a/install-beef
+++ b/install-beef
@@ -41,7 +41,7 @@ fi
 if [ "$OS" == "Darwin" ]; then
 	echo "Mac OSX Detected"
 	echo "Installing Ruby Version Manager (RVM) & Ruby 1.9.3.."
-	bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer) 
+	bash -s stable < <(curl -Ls https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
 	source ~/.bash_login
 	rvm install 1.9.3-p0 --with-gcc=clang
 	rvm use 1.9.3-p0
@@ -78,7 +78,7 @@ if [ "$Distro" == "Debian" ]; then
 
 sudo apt-get install build-essential openssl libreadline6 libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev libncurses5-dev automake libtool bison subversion
 
-curl -sk https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash
+curl -Lsk https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash
 
 echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"' >> ~/.bashrc
 


### PR DESCRIPTION
GitHub has started to redirect raw.github.com to
raw.githubusercontent.com, breaking the installation scripts.
Paramter -L makes curl follow the redirect.
