### PR TITLE
This is needed for BeEF to work on Ubuntu Trusty 64bit ruby-1.9.3-p448 (...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,10 @@ if RUBY_PLATFORM.downcase.include?("mswin") || RUBY_PLATFORM.downcase.include?("
   gem "execjs"
   gem "win32console"
 elsif !RUBY_PLATFORM.downcase.include?("darwin")
-  gem "therubyracer"
+  gem "therubyracer", "0.11.3"
   gem "execjs"
 end
+ 
 
 gem "ansi"
 gem "term-ansicolor", :require => "term/ansicolor"


### PR DESCRIPTION
...via rvm)

Without adding this you will get the errors as reported here: http://stackoverflow.com/questions/25779927/segmentation-fault-when-compile-assets-in-rails
