### PR TITLE
Do not assume 80 to be the default port for HTTPS

### DIFF
--- a/core/main/client/browser.js
+++ b/core/main/client/browser.js
@@ -1995,7 +1995,17 @@ beef.browser = {
         var page_uri = (document.location.href) ? document.location.href : "Unknown";
         var page_referrer = (document.referrer) ? document.referrer : "Unknown";
         var hostname = (document.location.hostname) ? document.location.hostname : "Unknown";
-        var hostport = (document.location.port) ? document.location.port : "80";
+        switch (document.location.protocol) {
+            case "http:":
+                var default_port = "80";
+                break;
+            case "https:":
+                var default_port = "443";
+                break
+            default:
+                var default_port = "";
+        }
+        var hostport = (document.location.port) ? document.location.port : default_port;
         var browser_plugins = beef.browser.getPlugins();
         var date_stamp = new Date().toString();
         var os_name = beef.os.getName();

--- a/core/main/handlers/browserdetails.rb
+++ b/core/main/handlers/browserdetails.rb
@@ -38,10 +38,17 @@ module BeEF
           zombie.firstseen = Time.new.to_i
 
           # hostname
+          log_zombie_port = 0
           if not @data['results']['HostName'].nil? then
             log_zombie_domain=@data['results']['HostName']
           elsif (not @data['request'].referer.nil?) and (not @data['request'].referer.empty?)
-            log_zombie_domain=@data['request'].referer.gsub('http://', '').gsub('https://', '').split('/')[0]
+            referer = @data['request'].referer
+            if referer.start_with?("https://") then
+              log_zombie_port = 443
+            else
+              log_zombie_port = 80
+            end
+            log_zombie_domain=referer.gsub('http://', '').gsub('https://', '').split('/')[0]
           else
             log_zombie_domain="unknown" # Probably local file open
           end
@@ -51,7 +58,6 @@ module BeEF
             log_zombie_port=@data['results']['HostPort']
           else
             log_zombie_domain_parts=log_zombie_domain.split(':')
-            log_zombie_port=80
             if log_zombie_domain_parts.length > 1 then
               log_zombie_port=log_zombie_domain_parts[1].to_i
             end


### PR DESCRIPTION
The default port for HTTPS is 443, therefore use it and not 80 if no
specific port is set.
