### PR TITLE
Fixed Flash detection for IE11

### DIFF
--- a/core/main/client/browser.js
+++ b/core/main/client/browser.js
@@ -965,6 +965,14 @@ beef.browser = {
     isC43: function () {
         return (!!window.chrome && !!window.fetch && !window.webkitPerformance && window.navigator.appVersion.match(/Chrome\/(\d+)\./)) && ((parseInt(window.navigator.appVersion.match(/Chrome\/(\d+)\./)[1], 10) == 43) ? true : false);
     },
+    
+    /**
+     * Returns true if Chrome 44.(adds !!window.fetch check too)
+     * @example: beef.browser.isC44()
+     */
+    isC44: function () {
+        return (!!window.chrome && !!window.fetch && !window.webkitPerformance && window.navigator.appVersion.match(/Chrome\/(\d+)\./)) && ((parseInt(window.navigator.appVersion.match(/Chrome\/(\d+)\./)[1], 10) == 44) ? true : false);
+    },
 
     /**
      * Returns true if Chrome for iOS 42.
@@ -979,7 +987,7 @@ beef.browser = {
      * @example: beef.browser.isC()
      */
     isC: function () {
-        return this.isC5() || this.isC6() || this.isC7() || this.isC8() || this.isC9() || this.isC10() || this.isC11() || this.isC12() || this.isC13() || this.isC14() || this.isC15() || this.isC16() || this.isC17() || this.isC18() || this.isC19() || this.isC19iOS() || this.isC20() || this.isC20iOS() || this.isC21() || this.isC21iOS() || this.isC22() || this.isC22iOS() || this.isC23() || this.isC23iOS() || this.isC24() || this.isC24iOS() || this.isC25() || this.isC25iOS() || this.isC26() || this.isC26iOS() || this.isC27() || this.isC27iOS() || this.isC28() || this.isC28iOS() || this.isC29() || this.isC29iOS() || this.isC30() || this.isC30iOS() || this.isC31() || this.isC31iOS() || this.isC32() || this.isC32iOS() || this.isC33() || this.isC33iOS() || this.isC34() || this.isC34iOS() || this.isC35() || this.isC35iOS() || this.isC36() || this.isC36iOS() || this.isC37() || this.isC37iOS() || this.isC38() || this.isC38iOS() || this.isC39() || this.isC39iOS() || this.isC40() || this.isC40iOS() || this.isC41() || this.isC41iOS() || this.isC42() || this.isC43() || this.isC42iOS();
+        return this.isC5() || this.isC6() || this.isC7() || this.isC8() || this.isC9() || this.isC10() || this.isC11() || this.isC12() || this.isC13() || this.isC14() || this.isC15() || this.isC16() || this.isC17() || this.isC18() || this.isC19() || this.isC19iOS() || this.isC20() || this.isC20iOS() || this.isC21() || this.isC21iOS() || this.isC22() || this.isC22iOS() || this.isC23() || this.isC23iOS() || this.isC24() || this.isC24iOS() || this.isC25() || this.isC25iOS() || this.isC26() || this.isC26iOS() || this.isC27() || this.isC27iOS() || this.isC28() || this.isC28iOS() || this.isC29() || this.isC29iOS() || this.isC30() || this.isC30iOS() || this.isC31() || this.isC31iOS() || this.isC32() || this.isC32iOS() || this.isC33() || this.isC33iOS() || this.isC34() || this.isC34iOS() || this.isC35() || this.isC35iOS() || this.isC36() || this.isC36iOS() || this.isC37() || this.isC37iOS() || this.isC38() || this.isC38iOS() || this.isC39() || this.isC39iOS() || this.isC40() || this.isC40iOS() || this.isC41() || this.isC41iOS() || this.isC42() || this.isC43() || this.isC42iOS() || this.isC44();
     },
 
     /**
@@ -1114,6 +1122,7 @@ beef.browser = {
             C41iOS: this.isC41iOS(), // Chrome 41 on iOS
             C42: this.isC42(), // Chrome 42
             C43: this.isC43(), // Chrome 43
+            C44: this.isC44(), // Chrome 44
             C42iOS: this.isC42iOS(), // Chrome 42 on iOS
 
             C: this.isC(), // Chrome any version
@@ -1438,6 +1447,10 @@ beef.browser = {
         ;   // Chrome 42
         if (this.isC43()) {
             return '43'
+        }
+        ;
+        if (this.isC44()) {
+            return '44'
         }
         ;
         if (this.isC42iOS()) {

--- a/core/main/client/browser.js
+++ b/core/main/client/browser.js
@@ -1745,19 +1745,28 @@ beef.browser = {
             flash_versions = 12;
             flash_installed = false;
 
-            if (window.ActiveXObject) {
-                for (x = 2; x <= flash_versions; x++) {
-                    try {
-                        Flash = eval("new ActiveXObject('ShockwaveFlash.ShockwaveFlash." + x + "');");
-                        if (Flash) {
-                            flash_installed = true;
+            if (this.type().IE11) {
+            	// see: 
+            	// http://stackoverflow.com/questions/19638981/window-activexobject-difference-in-ie11
+            	// http://msdn.microsoft.com/en-us/library/ie/dn423948%28v=vs.85%29.aspx
+            	
+            	flash_installed = (navigator.plugins["Shockwave Flash"] != undefined);
+            } else {
+            	if (window.ActiveXObject != null) {
+                    for (x = 2; x <= flash_versions; x++) {
+                        try {
+                            Flash = eval("new ActiveXObject('ShockwaveFlash.ShockwaveFlash." + x + "');");
+                            if (Flash) {
+                                flash_installed = true;
+                            }
                         }
-                    }
-                    catch (e) {
-                        beef.debug("Creating Flash ActiveX object failed: " + e.message);
+                        catch (e) {
+                            beef.debug("Creating Flash ActiveX object failed: " + e.message);
+                        }
                     }
                 }
             }
+            
             return flash_installed;
         }
     },


### PR DESCRIPTION
Object window.ActiveXObject is not available in IE11. So, the Flash detection fails in IE11, even Flash Players installed and works well. 

See details here:
http://stackoverflow.com/questions/19638981/window-activexobject-difference-in-ie11
http://msdn.microsoft.com/en-us/library/ie/dn423948%28v=vs.85%29.aspx