### PR TITLE
Add IPv6 Support to get_internal_ip_webrtc command

### DIFF
--- a/modules/host/get_internal_ip_webrtc/command.js
+++ b/modules/host/get_internal_ip_webrtc/command.js
@@ -15,7 +15,8 @@ beef.execute(function() {
 
 	    // Construct RTC peer connection
 	    var servers = {iceServers:[]};
-	    var rtc = new RTCPeerConnection(servers);
+	    var mediaConstraints = {optional:[{googIPv6: true}]};
+	    var rtc = new RTCPeerConnection(servers, mediaConstraints);
 	    rtc.createDataChannel('', {reliable:false});
 
 	    // Upon an ICE candidate being found


### PR DESCRIPTION
This update adds support for IPv6 to the RTCPeerConnection revealing internal IPv6 addresses as well.