### PR TITLE
Add logic for beef.browser.javaEnabled function

### DIFF
--- a/core/main/client/browser.js
+++ b/core/main/client/browser.js
@@ -1951,13 +1951,8 @@ beef.browser = {
      * @example: if(beef.browser.javaEnabled()) { ... }
      */
     javaEnabled: function () {
-        //Use of deployJava defined in deployJava.js (Oracle java deployment toolkit)
-        // versionJRE = deployJava.getJREs();
 
-        // if(versionJRE != '')
-        //     return true;
-        //  else
-        return false;
+        return navigator.javaEnabled();
 
     },
 


### PR DESCRIPTION
Modified core/main/client/browser.js's beef.browser.javaEnabled to return the result of calling Window.navigator.javaEnabled instead of only returning false.

This method should be compatible with all major browsers:
<img width="865" alt="javaenabledsupport" src="https://cloud.githubusercontent.com/assets/9021719/9842890/3c3444fa-5a69-11e5-9b12-22957090e2ee.png">
