### PR TITLE
Fix "ALL" comparison for browser and os

### DIFF
--- a/core/main/autorun_engine/engine.rb
+++ b/core/main/autorun_engine/engine.rb
@@ -357,7 +357,7 @@ module BeEF
           if rule_id != nil
             rules = [BeEF::Core::AutorunEngine::Models::Rule.get(rule_id)]
           else
-            rules = BeEF::Core::AutorunEngine::Models::Rule.all(:browser => browser)
+            rules = BeEF::Core::AutorunEngine::Models::Rule.all()
           end
           return nil if rules == nil
 

--- a/core/main/autorun_engine/engine.rb
+++ b/core/main/autorun_engine/engine.rb
@@ -403,8 +403,8 @@ module BeEF
               # os_ver without checks as it can be very different or even empty, for instance on linux/bsd)
 
               # check if the browser and OS types do match
-              next unless browser == 'ALL'  || browser == rule.browser
-              next unless os == 'ALL'       || os == rule.os
+              next unless rule.browser == 'ALL'  || browser == rule.browser
+              next unless rule.os == 'ALL'       || os == rule.os
 
               # check if the browser version match
               browser_version_match = compare_versions(browser_version.to_s, b_ver_cond, b_ver.to_s)


### PR DESCRIPTION
The correct is to check if the *rule.browser* has the tag "ALL", not if the browser was identified as "ALL", which of course never happen.
Before this fix, using "ALL" in a ARE rule makes it be never called.