### PR TITLE
Update loader.rb to include optparse

### DIFF
--- a/core/loader.rb
+++ b/core/loader.rb
@@ -17,6 +17,7 @@ require 'xmlrpc/client'
 require 'openssl'
 require 'rubydns'
 require 'mime/types'
+require 'optparse'
 
 # @note Include the filters
 require 'core/filters'


### PR DESCRIPTION
Fixes #1216 by loading the 'optparse' library in ```core/loader.rb```.