### PR TITLE
Omit Transfer-Encoding header in proxy responses

### DIFF
--- a/extensions/proxy/proxy.rb
+++ b/extensions/proxy/proxy.rb
@@ -157,6 +157,7 @@ module BeEF
               "Connection",
               "Expires",
               "Accept-Ranges",
+              "Transfer-Encoding",
               "Date"]
             headers.each_line do |line|
               # stripping the Encoding, Cache and other headers


### PR DESCRIPTION
Beef automatically calculates and inserts a Content-Length header when
sending proxy responses. If the Transfer-Encoding header is not
stripped, many browsers treat this as a Content-Length of 0, thus
rendering an empty body.

This fixes Issue #1048 