### PR TITLE
Add Pushover notification channel

### DIFF
--- a/extensions/notifications/channels/pushover.rb
+++ b/extensions/notifications/channels/pushover.rb
@@ -13,7 +13,6 @@ module Channels
             # Configure the Pushover Client
             client = Rushover::Client.new(@config.get('beef.extension.notifications.pushover.app_key'))
 
-            # Pushover.notification(message: message, title: "BeEF Notification")
             client.notify(@config.get('beef.extension.notifications.pushover.user_key'), message)
         end
     end

--- a/extensions/notifications/channels/pushover.rb
+++ b/extensions/notifications/channels/pushover.rb
@@ -1,0 +1,23 @@
+require 'rushover'
+
+module BeEF
+module Extension
+module Notifications
+module Channels
+
+    class Pushover
+
+        def initialize(message)
+            @config = BeEF::Core::Configuration.instance
+
+            # Configure the Pushover Client
+            client = Rushover::Client.new(@config.get('beef.extension.notifications.pushover.app_key'))
+
+            # Pushover.notification(message: message, title: "BeEF Notification")
+            client.notify(@config.get('beef.extension.notifications.pushover.user_key'), message)
+        end
+    end
+end
+end
+end
+end

--- a/extensions/notifications/config.yaml
+++ b/extensions/notifications/config.yaml
@@ -24,7 +24,7 @@ beef:
               smtp_host: 127.0.0.1
               smtp_port: 25
             pushover:
-              enable: true
+              enable: false
               user_key: pushover_user_key
               app_key: pushover_api_key
 

--- a/extensions/notifications/config.yaml
+++ b/extensions/notifications/config.yaml
@@ -23,3 +23,8 @@ beef:
               to_address: receipient_email_address
               smtp_host: 127.0.0.1
               smtp_port: 25
+            pushover:
+              enable: true
+              user_key: pushover_user_key
+              app_key: pushover_api_key
+

--- a/extensions/notifications/config.yaml
+++ b/extensions/notifications/config.yaml
@@ -23,6 +23,7 @@ beef:
               to_address: receipient_email_address
               smtp_host: 127.0.0.1
               smtp_port: 25
+            # Make sure you do 'gem install rushover' before enabling this feature.
             pushover:
               enable: false
               user_key: pushover_user_key

--- a/extensions/notifications/notifications.rb
+++ b/extensions/notifications/notifications.rb
@@ -6,6 +6,7 @@
 
 require 'extensions/notifications/channels/tweet'
 require 'extensions/notifications/channels/email'
+require 'extensions/notifications/channels/pushover'
 
 module BeEF
 module Extension
@@ -38,6 +39,10 @@ module Notifications
       if @config.get('beef.extension.notifications.email.enable') == true
         to_address    = @config.get('beef.extension.notifications.email.to_address')
         BeEF::Extension::Notifications::Channels::Email.new(to_address,message)
+      end
+
+      if @config.get('beef.extension.notifications.pushover.enable') == true
+        BeEF::Extension::Notifications::Channels::Pushover.new(message)
       end
     end
 


### PR DESCRIPTION
This adds [Pushover](https://pushover.net/) support as a notification channel to BeEF.

To test, edit the `config.yaml` for your beef project, and ensure the following is present:

```yaml
    extension:
        notifications:
            enable: true
```

In `extensions/notifications/config.yaml`, enable the `pushover` module, replace `pushover_user_key` with your pushover user api key, and replace `pushover_api_key` with the app token you created for BeEF in the Pushover console.

Finally, install the `rushover` gem with `gem install 'rushover'`