### PR TITLE
Add Slack notifications to Notifications extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ end
 group :ext_notifications do
   # Pushover
   gem 'rushover'
+  # Slack
+  gem 'slack-notifier'
   # Twitter
   gem 'twitter', '>= 5.0.0'
 end

--- a/extensions/notifications/channels/slack_workspace.rb
+++ b/extensions/notifications/channels/slack_workspace.rb
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2006-2017 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+require 'slack-notifier'
+
+module BeEF
+module Extension
+module Notifications
+module Channels
+
+  class SlackWorkspace
+
+    def initialize(message)
+      @config = BeEF::Core::Configuration.instance
+
+      # Configure the Slack Client
+      webhook_url = @config.get('beef.extension.notifications.slack.webhook_url')
+      channel = @config.get('beef.extension.notifications.slack.channel')
+      username = @config.get('beef.extension.notifications.slack.username')
+
+      if webhook_url =~ /your_webhook_url/ or webhook_url !~ %r{^https://hooks\.slack\.com\/services\/}
+        print_error '[Notifications] Invalid Slack WebHook URL'
+        return
+      end
+
+      notifier = Slack::Notifier.new webhook_url,
+                                     channel: channel,
+                                     username: username,
+                                     http_options: { open_timeout: 10 }
+
+      notifier.ping message
+    rescue => e
+      print_error "[Notifications] Slack notification initialization failed: #{e.message}"
+    end
+  end
+end
+end
+end
+end

--- a/extensions/notifications/config.yaml
+++ b/extensions/notifications/config.yaml
@@ -6,10 +6,8 @@
 beef:
     extension:
         notifications:
-            enable: false 
+            enable: false
             name: Notifications
-            # Make sure you do 'gem install twitter' before enabling this feature. Leaving the twitter gem
-            # in the Gemfile causes dependency issues, and this twitter feature isn't used much anyway.
             twitter:
               enable: false
               consumer_key: app_consumer_key
@@ -23,9 +21,15 @@ beef:
               to_address: receipient_email_address
               smtp_host: 127.0.0.1
               smtp_port: 25
-            # Make sure you do 'gem install rushover' before enabling this feature.
             pushover:
               enable: false
               user_key: pushover_user_key
               app_key: pushover_api_key
-
+            # To enable WebHooks for your Slack workspace,
+            # go to: https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
+            # Select "Add Configuration", then "Add Incoming WebHooks integration"
+            slack:
+              enable: false
+              webhook_url: "your_webhook_url"
+              channel: "#beef"     # Slack channel
+              username: "notifier" # Username can be anything

--- a/extensions/notifications/notifications.rb
+++ b/extensions/notifications/notifications.rb
@@ -7,6 +7,7 @@
 require 'extensions/notifications/channels/tweet'
 require 'extensions/notifications/channels/email'
 require 'extensions/notifications/channels/pushover'
+require 'extensions/notifications/channels/slack_workspace'
 
 module BeEF
 module Extension
@@ -43,6 +44,10 @@ module Notifications
 
       if @config.get('beef.extension.notifications.pushover.enable') == true
         BeEF::Extension::Notifications::Channels::Pushover.new(message)
+      end
+
+      if @config.get('beef.extension.notifications.slack.enable') == true
+        BeEF::Extension::Notifications::Channels::SlackWorkspace.new(message)
       end
     end
 


### PR DESCRIPTION
This PR adds Slack notifications to the Notifications extension.

![slack](https://user-images.githubusercontent.com/434827/31584242-be8522b2-b1f6-11e7-862c-8f5f67a20333.png)
