### PR TITLE
Add error messages to pushover notification channel

### DIFF
--- a/extensions/notifications/channels/pushover.rb
+++ b/extensions/notifications/channels/pushover.rb
@@ -13,10 +13,14 @@ module Channels
             # Configure the Pushover Client
             client = Rushover::Client.new(@config.get('beef.extension.notifications.pushover.app_key'))
 
-            client.notify(@config.get('beef.extension.notifications.pushover.user_key'), message)
+            res = client.notify(@config.get('beef.extension.notifications.pushover.user_key'), message)
+            print_error '[Notifications] Pushover notification failed' unless res.ok?
+        rescue Exception => e
+            print_error "[Notifications] Pushover notification initalization failed: '#{e.message}'"
         end
     end
 end
 end
 end
 end
+

--- a/extensions/notifications/channels/pushover.rb
+++ b/extensions/notifications/channels/pushover.rb
@@ -15,7 +15,7 @@ module Channels
 
             res = client.notify(@config.get('beef.extension.notifications.pushover.user_key'), message)
             print_error '[Notifications] Pushover notification failed' unless res.ok?
-        rescue Exception => e
+        rescue => e
             print_error "[Notifications] Pushover notification initialization failed: '#{e.message}'"
         end
     end

--- a/extensions/notifications/channels/pushover.rb
+++ b/extensions/notifications/channels/pushover.rb
@@ -16,7 +16,7 @@ module Channels
             res = client.notify(@config.get('beef.extension.notifications.pushover.user_key'), message)
             print_error '[Notifications] Pushover notification failed' unless res.ok?
         rescue Exception => e
-            print_error "[Notifications] Pushover notification initalization failed: '#{e.message}'"
+            print_error "[Notifications] Pushover notification initialization failed: '#{e.message}'"
         end
     end
 end


### PR DESCRIPTION
Adds error notifications to the recently added pushover channel.

A sample error notification in the console will look like:

```
[*] BeEF server started (press control+c to stop)
[!] [Notifications] Pushover notification initialization failed: 'Failed to open TCP connection to api.pushover.net:443 (Connection refused - connect(2) for "api.pushover.net" port 443)'
```
