### PR TITLE
Fixing syntax error in identify_lan_subnets

### DIFF
--- a/modules/network/identify_lan_subnets/command.js
+++ b/modules/network/identify_lan_subnets/command.js
@@ -109,7 +109,6 @@ var doScan = function(timeout) {
     } else {
       beef.debug("[command #<%= @command_id %>] Identifying LAN hosts completed.");
       beef.net.send('<%= @command_url %>', <%= @command_id %>, 'hosts='+hosts, beef.are.status_success());
-);
       beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=scan complete");
     }
   }


### PR DESCRIPTION
I've removed an erroneous `);`