### PR TITLE
Add install_mac logic

### DIFF
--- a/install
+++ b/install
@@ -17,7 +17,7 @@ RUBYSUFFIX=''
 
 command_exists () {
 
-  command -v "$1" /dev/null 2&>/dev/null
+  command -v "${1}" >/dev/null 2>&1
 }
 
 

--- a/install
+++ b/install
@@ -115,8 +115,29 @@ install_freebsd () {
 }
 
 install_mac () {
-  # brew install ...
-  echo
+
+  local mac_deps=(curl git nodejs python3 \
+  openssl readline libyaml sqlite3 libxml2 \
+  autoconf ncurses automake libtool \
+  bison wget)
+
+  if command_exists brew; then
+    fatal "Homebrew (https://brew.sh/) required to install dependencies"
+  fi
+  
+  info "Installing dependencies via brew"
+
+  brew update 
+
+  for package in "${mac_deps[@]}"; do
+
+    if brew install "${package}"; then
+      info "${package} installed"
+    else
+      fatal "Failed to install ${package}"
+    fi
+    
+  done
 }
 
 

--- a/install
+++ b/install
@@ -121,7 +121,7 @@ install_mac () {
   autoconf ncurses automake libtool \
   bison wget)
 
-  if command_exists brew; then
+  if ! command_exists brew; then
     fatal "Homebrew (https://brew.sh/) required to install dependencies"
   fi
   


### PR DESCRIPTION
Addresses part of #1477.

Uses homebrew (`brew`) to install dependencies. 

Checks if homebrew is installed, if not exits.

If homebrew is present runs `brew update` to get the latest formula then runs `brew install ${package}`.
