### PR TITLE
Remove the dependency on therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,6 @@ gem 'espeak-ruby', '>= 1.0.4' # Text-to-Voice
 gem 'nokogiri', '>= 1.7'
 gem 'rake'
 
-if RUBY_PLATFORM.downcase.include?('linux')
-  gem 'therubyracer', '0.12.3'
-end
-
 # SQLite support
 group :sqlite do
   gem 'dm-sqlite-adapter'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Requirements
 * Operating System: Mac OSX 10.5.0 or higher / modern Linux
 * [Ruby](http://ruby-lang.org): 2.3 or newer
 * [SQLite](http://sqlite.org): 3.x
+* [Node.js] (https://nodejs.org): 6 or newer
 * The gems listed in the Gemfile: https://github.com/beefproject/beef/blob/master/Gemfile
 * brew install selenium-server-standalone (See https://github.com/shvets/selenium)
 


### PR DESCRIPTION
therubyracer has long been unmaintained which is causing both security and build
issues to go unfixed. As beef depends on it only to provide a JS runtime for
execjs, we can drop it and require users to install Node.js. execjs
automatically finds the node binary and uses it as a JS runtime.

This fixes #1478, #1045, #1046, #1249, #1374, #1377, #1395, #1396, #1428, #1429
This also fixes #1433, #1502, #1504, #1540, #1545, #1547