### PR TITLE
Detects Manjaro as an Arch distro

### DIFF
--- a/install
+++ b/install
@@ -89,7 +89,7 @@ install_linux () {
     DISTRO_ID=$(cat /etc/os-release | grep  ID= | cut -d= -f2-)
     if [ "${DISTRO_ID}" = 'kali' ] ; then
       Distro='Kali'
-    elif [ "${DISTRO_ID}" = 'arch' ] ; then
+    elif [ "${DISTRO_ID}" = 'arch' ] || [ "${DISTRO_ID}" = 'manjaro' ] ; then
       Distro='Arch'
     fi
   fi


### PR DESCRIPTION
Manjaro is a distro based on Arch, but it's os-release file is not marked as Arch.
This change provides support to this distribution for easy install.