### PR TITLE
Added ruby-dev package for Debian and Kali

### DIFF
--- a/install
+++ b/install
@@ -103,7 +103,7 @@ install_linux () {
   info "Installing ${Distro} prerequisite packages..."
   if [ "${Distro}" = "Debian" ] || [ "${Distro}" = "Kali" ]; then
     sudo apt-get update
-    sudo apt-get install curl git build-essential openssl libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev libncurses5-dev automake libtool bison nodejs
+    sudo apt-get install curl git build-essential openssl libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev libncurses5-dev automake libtool bison nodejs ruby-dev
   elif [ "${Distro}" = "RedHat" ]; then
     sudo yum install -y git make gcc openssl-devel gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs
   elif [ "${Distro}" = "Arch" ]; then


### PR DESCRIPTION
Without package "ruby-dev", I got this error on my Kali Linux:

Building native extensions. This could take a while...
ERROR:  Error installing json:
	ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.5.0/gems/json-1.8.6/ext/json/ext/generator
/usr/bin/ruby2.5 -r ./siteconf20190117-11443-w5znm6.rb extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h