### PR TITLE
Uncomment beef_init

### DIFF
--- a/core/main/client/timeout.js
+++ b/core/main/client/timeout.js
@@ -14,4 +14,4 @@
  Cheers to John Wilander that discussed this bug with me at OWASP AppSec Research Greece
  antisnatchor
  */
-//setTimeout(beef_init, 1000);
+setTimeout(beef_init, 1000);


### PR DESCRIPTION
May or may not break the ARE.

The `setTimeout` call for `beef_init` is required for hooking in instances where the script is loaded after page load. This is possible is several scenarios, such as DOM XSS, using the `Hook Me!` bookmarklet, and hooking via XSS in Flash objects (probably - untested).
