### PR TITLE
Excluding BUILD_ID while getting the distro ID

### DIFF
--- a/install
+++ b/install
@@ -86,7 +86,7 @@ install_linux () {
     Distro='Alpine'
   elif [ -f /etc/os-release ] ; then
     #DISTRO_ID=$(grep ^ID= /etc/os-release | cut -d= -f2-)
-    DISTRO_ID=$(cat /etc/os-release | grep  ID= | cut -d= -f2-)
+    DISTRO_ID=$(cat /etc/os-release | grep  ID= | grep -v "BUILD" | cut -d= -f2-)
     if [ "${DISTRO_ID}" = 'kali' ] ; then
       Distro='Kali'
     elif [ "${DISTRO_ID}" = 'arch' ] || [ "${DISTRO_ID}" = 'manjaro' ] ; then


### PR DESCRIPTION
I just installed BeEF in Arch Linux and it returned an error saying it couldn't detect my Linux distro, then I noticed this line:

`DISTRO_ID=$(cat /etc/os-release | grep  ID= | cut -d= -f2-)`

it was returning the next output:

`arch
rolling`

It was getting the value of ID and BUILD_ID, so I excluded BUILD_ID to get just the ID value:

`cat /etc/os-release | grep  ID= | grep -v "BUILD" | cut -d= -f2-`