### PR TITLE
proxy:ignore case when ignoring headers

### DIFF
--- a/extensions/proxy/proxy.rb
+++ b/extensions/proxy/proxy.rb
@@ -171,7 +171,7 @@ module BeEF
               header_key = line.split(': ')[0]
               header_value = line.split(': ')[1]
               next if header_key.nil?
-              next if ignore_headers.include?(header_key)
+              next if ignore_headers.any?{ |h| h.casecmp(header_key) == 0 }
               if header_value.nil?
                 #headers_hash[header_key] = ""
               else


### PR DESCRIPTION
I noticed proxying wasn't working with a site that returns all it's headers in lowercase. Although it would be preferable if the application returned the conventional-cased headers, the HTTP 1.1 RFC specifically [calls out](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) headers as case-insensitive. This change allowed me to use the proxy with the site.