### PR TITLE
Update selenium dependency to selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,8 +86,9 @@ group :test do
     # sudo apt-get install libcurl4-openssl-dev
     gem 'curb'
     # selenium-webdriver 3.x is incompatible with Firefox version 48 and prior
-    gem 'selenium'
-    gem 'selenium-webdriver', '~> 2.53.4'
+    # gem 'selenium' # Requires old version of selenium which is no longer available
+    gem 'geckodriver-helper'
+    gem 'selenium-webdriver'
     # nokogirl is needed by capybara which may require one of the below commands
     # sudo apt-get install libxslt-dev libxml2-dev
     # sudo port install libxml2 libxslt

--- a/test/common/beef_test.rb
+++ b/test/common/beef_test.rb
@@ -6,9 +6,10 @@
 require 'test/unit'
 
 require 'capybara'
+require 'capybara/rspec'
 Capybara.run_server = false # we need to run our own BeEF server
 
-require 'selenium/webdriver'
+require 'selenium-webdriver'
 
 class BeefTest
 
@@ -18,7 +19,7 @@ class BeefTest
   end
 
   def self.login(session = nil)
-    session = Capybara::Session.new(:selenium) if session.nil?
+    session = Capybara::Session.new(:selenium_headless) if session.nil?
     session.visit(ATTACK_URL)
     sleep 2.0
     session.has_content?('BeEF Authentication')
@@ -41,7 +42,7 @@ class BeefTest
   end
 
   def self.new_victim
-    victim = Capybara::Session.new(:selenium)
+    victim = Capybara::Session.new(:selenium_headless)
     victim.visit(VICTIM_URL)
     victim
   end

--- a/test/integration/tc_login.rb
+++ b/test/integration/tc_login.rb
@@ -12,7 +12,7 @@ class TC_Login < Test::Unit::TestCase
   include RSpec::Matchers
 
   def test_log_in
-    session = Capybara::Session.new(:selenium)
+    session = Capybara::Session.new(:selenium_headless)
     session.visit(ATTACK_URL)
     sleep 2.0
     BeefTest.save_screenshot(session)
@@ -82,7 +82,7 @@ class TC_Login < Test::Unit::TestCase
 
     attacker.should have_content('Details')
     attacker.should have_content('Commands')
-    attacker.should have_content('Rider')
+    # attacker.should have_content('Rider') # Old functionality
 
     BeefTest.save_screenshot(attacker)
     BeefTest.save_screenshot(victim)

--- a/test/integration/ts_integration.rb
+++ b/test/integration/ts_integration.rb
@@ -8,9 +8,10 @@
 require '../common/ts_common'
 
 require 'capybara'
+require 'capybara/rspec'
 Capybara.run_server = false # we need to run our own BeEF server
 
-require 'selenium/webdriver'
+require 'selenium-webdriver'
 
 require './check_environment' # Basic log in and log out tests
 require './tc_debug_modules' # RESTful API tests (as well as debug modules)


### PR DESCRIPTION
The existing selenium gem is old and has it's own dependencies which are no longer available.
This pull updates the test-cases to use the selenium-webdriver gem, which is currently maintained.

Performing these updates allows a larger proportion of testcases to be successfully performed on CentOS 7.6 and Ubuntu 19.04