### PR TITLE
Fixed OpenStreetMap

### DIFF
--- a/core/main/client/geolocation.js
+++ b/core/main/client/geolocation.js
@@ -40,16 +40,17 @@ beef.geolocation = {
                 },
             success: function(data, status, xhr){
                 beef.debug("[geolocation.js] openstreetmap success");
-                var jsonResp = $j.parseJSON(data);
+                //var jsonResp = $j.parseJSON(data);
 
                 beef.net.send(command_url, command_id, "latitude=" + latitude
                              + "&longitude=" + longitude
 //                             + "&osm=" + encodeURI(jsonResp.display_name)
-                              + "&osm=tofix"
+                              + "&osm=" + data.display_name
                              + "&geoLocEnabled=True");
                 },
             type: "get",
-            url: "http://nominatim.openstreetmap.org/reverse?format=json&lat=" +
+	    dataType: "json",
+            url: "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=" +
                 latitude + "&lon=" + longitude + "&zoom=18&addressdetails=1"
         });
 


### PR DESCRIPTION
Changed url from http to https, as it was getting blocked by Chrome in https sites. Added dataType "json", parseJSON not required so got rid of it. Changed format from json to jsonv2, as OSM was not sending a content type header in "json" but does send an "application/json" header in jsonv2, this fixes Cross Origin Read Blocking in Chrome (https://www.chromestatus.com/feature/5629709824032768).