### PR TITLE
Fixing random fails in auth_rate_spec.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ extensions/metasploit/msf-exploits.cache
 # ruby debugging
 .byebug_history
 
+
 # The following lines were created by https://www.gitignore.io
 
 ### Linux ###

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,14 @@ custom-config.yaml
 .DS_Store
 .gitignore
 .rvmrc
+beef.log
 
 *.lock
 
 extensions/metasploit/msf-exploits.cache
+
+# ruby debugging
+.byebug_history
 
 # The following lines were created by https://www.gitignore.io
 

--- a/spec/beef/api/auth_rate_spec.rb
+++ b/spec/beef/api/auth_rate_spec.rb
@@ -6,61 +6,62 @@
 
 RSpec.describe 'BeEF API Rate Limit' do
 
-	before(:all) do
-		# Note: rake spec passes --patterns which causes BeEF to pickup this argument via optparse. I can't see a better way at the moment to filter this out. Therefore ARGV=[] for this test.
-		ARGV = []
-		DataMapper.setup(:default, 'sqlite3::memory:')
-		DataMapper.auto_migrate!
-		@config = BeEF::Core::Configuration.instance
-		http_hook_server = BeEF::Core::Server.instance
-		http_hook_server.prepare
-		BeEF::API::Registrar.instance.fire(BeEF::API::Server, 'pre_http_start', http_hook_server)
-		@pid = fork do
-			http_hook_server.start
-		end
-		# wait for server to start
-		sleep 1
-	end
+  before(:all) do
+    # Note: rake spec passes --patterns which causes BeEF to pickup this argument via optparse. I can't see a better way at the moment to filter this out. Therefore ARGV=[] for this test.
+    ARGV = []
+    DataMapper.setup(:default, 'sqlite3::memory:')
+    DataMapper.auto_migrate!
+    @config = BeEF::Core::Configuration.instance
+    http_hook_server = BeEF::Core::Server.instance
+    http_hook_server.prepare
+    BeEF::API::Registrar.instance.fire(BeEF::API::Server, 'pre_http_start', http_hook_server)
+    @pid = fork do
+      http_hook_server.start
+    end
+    # wait for server to start
+    sleep 1
+  end
 
-	after(:all) do
-		Process.kill("INT",@pid)
-	end
+  after(:all) do
+    Process.kill("INT",@pid)
+  end
 
-	it 'adheres to auth rate limits' do
-		passwds = (1..9).map { |i| "broken_pass"}
-		passwds.push BEEF_PASSWD
-		apis = passwds.map { |pswd| BeefRestClient.new('http', ATTACK_DOMAIN, '3000', BEEF_USER, pswd) }
-		l = apis.length
-		#If this is failing with expect(test_api.auth()[:payload]["success"]).to be(true) expected true but received nil
-		#make sure in config.yaml the password = BEEF_PASSWD, which is currently 'beef'
-		(0..2).each do |again|      # multiple sets of auth attempts
-		  # first pass -- apis in order, valid passwd on 9th attempt
-		  # subsequent passes apis shuffled
-		  puts "speed requesets"    # all should return 401
-		  (0..50).each do |i|
-			# t = Time.now()
-			#puts "#{i} : #{t - t0} : #{apis[i%l].auth()[:payload]}"
-			test_api = apis[i%l]
-			expect(test_api.auth()[:payload]).to eql("401 Unauthorized") # all (unless the valid is first 1 in 10 chance)
-			# t0 = t
-		  end
-		  # again with more time between calls -- there should be success (1st iteration)
-		  puts "delayed requests"
-		  (0..(l*2)).each do |i|
-			# t = Time.now()
-			#puts "#{i} : #{t - t0} : #{apis[i%l].auth()[:payload]}"
-			test_api = apis[i%l]
-			if (test_api.is_pass?(BEEF_PASSWD))
-				expect(test_api.auth()[:payload]["success"]).to be(true) # valid pass should succeed
-			else
-				expect(test_api.auth()[:payload]).to eql("401 Unauthorized")
-			end
-			sleep(0.5)
-			# t0 = t
-		  end
-		  apis.shuffle! # new order for next iteration
-		  apis.reverse if (apis[0].is_pass?(BEEF_PASSWD)) # prevent the first from having valid passwd
-		end                         # multiple sets of auth attempts
-	end
+  it 'adheres to auth rate limits' do
+    passwds = (1..9).map { |i| "broken_pass"}
+    passwds.push BEEF_PASSWD
+    apis = passwds.map { |pswd| BeefRestClient.new('http', ATTACK_DOMAIN, '3000', BEEF_USER, pswd) }
+    l = apis.length
+    #If this is failing with expect(test_api.auth()[:payload]["success"]).to be(true) expected true but received nil
+    #make sure in config.yaml the password = BEEF_PASSWD, which is currently 'beef'
+    (0..2).each do |again|      # multiple sets of auth attempts
+      # first pass -- apis in order, valid passwd on 9th attempt
+      # subsequent passes apis shuffled
+      puts "speed requesets"    # all should return 401
+      (0..50).each do |i|
+      # t = Time.now()
+      #puts "#{i} : #{t - t0} : #{apis[i%l].auth()[:payload]}"
+        test_api = apis[i%l]
+        result = test_api.auth()[:payload]
+        expect(result).to eql("401 Unauthorized") # all (unless the valid is first 1 in 10 chance)
+      # t0 = t
+      end
+      # again with more time between calls -- there should be success (1st iteration)
+      puts "delayed requests"
+      (0..(l*2)).each do |i|
+        # t = Time.now()
+        #puts "#{i} : #{t - t0} : #{apis[i%l].auth()[:payload]}"
+        test_api = apis[i%l]
+        if (test_api.is_pass?(BEEF_PASSWD))
+          expect(test_api.auth()[:payload]["success"]).to be(true) # valid pass should succeed
+        else
+          expect(test_api.auth()[:payload]).to eql("401 Unauthorized")
+        end
+        sleep(0.5)
+      # t0 = t
+      end
+      apis.shuffle! # new order for next iteration
+      apis = apis.reverse if (apis[0].is_pass?(BEEF_PASSWD)) # prevent the first from having valid passwd
+    end                         # multiple sets of auth attempts
+  end
  
 end


### PR DESCRIPTION
auth_rate_spec.rb sometimes fails due to the the original apis.reverse call doesn't actually reverse the apis list (the changes are not stored.)

by changing it to 
```rb
apis = apis.reverse if (apis[0].is_pass?(BEEF_PASSWD))
```
this bug is fixed.

Also added beef.log and .byebug_history into the gitignore file to prevent data leaks