### PR TITLE
Add Ruby 2.7.0 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5.3
   - 2.6.0
   - 2.6.5
+  - 2.7.0
 notifications:
   email:
     recipients:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/