### PR TITLE
Fixed build_recursive_tree()

### DIFF
--- a/extensions/admin_ui/controllers/modules/modules.rb
+++ b/extensions/admin_ui/controllers/modules/modules.rb
@@ -149,15 +149,13 @@ class Modules < BeEF::Extension::AdminUI::HttpController
      newinput = cinput.split('/')
      newcinput = newinput.shift
      if parent.detect {|p| p['text'] == newcinput }.nil?
-       fldr = {'text' => newcinput, 'cls' => 'folder', 'children' => []}
-       parent << build_recursive_tree(fldr['children'],newinput)
-     else
-       parent.each {|p|
-         if p['text'] == newcinput
-           p['children'] = build_recursive_tree(p['children'],newinput)
-         end
-       }
-     end
+       parent << {'text' => newcinput, 'cls' => 'folder', 'children' => []}
+     end  
+     parent.each {|p|
+       if p['text'] == newcinput
+         p['children'] = build_recursive_tree(p['children'],newinput)
+       end
+     }
    end
 
     if input.count > 0


### PR DESCRIPTION
Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Bug

## Feature/Issue Description
There was a bug in the build_recursive_tree function, which was triggered when you
tried to generate folders which only contained subfolders (without modules).



