### PR TITLE
Changed how websocket hooked browsers time out

### DIFF
--- a/core/main/rest/handlers/hookedbrowsers.rb
+++ b/core/main/rest/handlers/hookedbrowsers.rb
@@ -3,7 +3,6 @@
 # Browser Exploitation Framework (BeEF) - http://beefproject.com
 # See the file 'doc/COPYING' for copying permission
 #
-require 'byebug'
 
 module BeEF
   module Core

--- a/core/main/rest/handlers/hookedbrowsers.rb
+++ b/core/main/rest/handlers/hookedbrowsers.rb
@@ -3,6 +3,7 @@
 # Browser Exploitation Framework (BeEF) - http://beefproject.com
 # See the file 'doc/COPYING' for copying permission
 #
+require 'byebug'
 
 module BeEF
   module Core
@@ -22,11 +23,18 @@ module BeEF
 
         #
         # @note Get online and offline hooked browsers details (like name, version, os, ip, port, ...)
+        # When websockets are enabled this will allow the ws_poll_timeout config to be used to check if the browser is online or not.
         #
         get '/' do
-          online_hooks = hb_to_json(BeEF::Core::Models::HookedBrowser.where('lastseen >= ?', (Time.new.to_i - 15)))
-          offline_hooks = hb_to_json(BeEF::Core::Models::HookedBrowser.where('lastseen <= ?', (Time.new.to_i - 15)))
-
+          if config.get('beef.http.websocket.enable') == false
+            online_hooks = hb_to_json(BeEF::Core::Models::HookedBrowser.where('lastseen >= ?', (Time.new.to_i - 15)))
+            offline_hooks = hb_to_json(BeEF::Core::Models::HookedBrowser.where('lastseen <= ?', (Time.new.to_i - 15)))
+          else
+            timeout = (config.get('beef.http.websocket.ws_poll_timeout').to_i / 1000) + 5
+            online_hooks = hb_to_json(BeEF::Core::Models::HookedBrowser.where('lastseen >= ?', (Time.new.to_i - timeout)))
+            offline_hooks = hb_to_json(BeEF::Core::Models::HookedBrowser.where('lastseen <= ?', (Time.new.to_i - timeout)))
+          end
+          
           output = {
               'hooked-browsers' => {
                   'online' => online_hooks,


### PR DESCRIPTION
Fixes a bug where adding a longer timeout for websocket polls causes the browser to show as offline in the ui panel.
