### PR TITLE
Replaced Array.prototype.unique with a cleaner jQuery equivalent

### DIFF
--- a/core/main/client/browser.js
+++ b/core/main/client/browser.js
@@ -3917,12 +3917,12 @@ beef.browser = {
     getPlugins: function () {
 
         var results;
-        Array.prototype.unique = function () {
-            var o = {}, i, l = this.length, r = [];
-            for (i = 0; i < l; i += 1) o[this[i]] = this[i];
-            for (i in o) r.push(o[i]);
-            return r;
-        };
+
+        function unique(array) {
+          return $.grep(array, function(el, index) {
+            return index === $.inArray(el, array);
+          });
+        }
 
         // Things lacking navigator.plugins
         if (!navigator.plugins) 
@@ -3941,8 +3941,8 @@ beef.browser = {
                 // Sometimes store the version in description (Real, Adobe)
                 else results[i] = navigator.plugins[i].name;// + '-desc.' + navigator.plugins[i].description;
             }
-            results = results.unique().toString();
-
+            results = unique(results).toString();
+            
             // All browsers that don't support navigator.plugins
         } else {
             results = new Array();

--- a/docs/browser.js.html
+++ b/docs/browser.js.html
@@ -3944,12 +3944,12 @@ beef.browser = {
     getPlugins: function () {
 
         var results;
-        Array.prototype.unique = function () {
-            var o = {}, i, l = this.length, r = [];
-            for (i = 0; i &lt; l; i += 1) o[this[i]] = this[i];
-            for (i in o) r.push(o[i]);
-            return r;
-        };
+
+        function unique(array) {
+          return $.grep(array, function(el, index) {
+            return index === $.inArray(el, array);
+          });
+        }
 
         // Things lacking navigator.plugins
         if (!navigator.plugins) 
@@ -3968,7 +3968,7 @@ beef.browser = {
                 // Sometimes store the version in description (Real, Adobe)
                 else results[i] = navigator.plugins[i].name;// + '-desc.' + navigator.plugins[i].description;
             }
-            results = results.unique().toString();
+            results = unique(results).toString();
 
             // All browsers that don't support navigator.plugins
         } else {

--- a/extensions/events/handler.rb
+++ b/extensions/events/handler.rb
@@ -42,7 +42,7 @@ module Events
 
       # push events to logger
         logger = BeEF::Core::Logger.instance
-        events.each do |key,value|
+        events.each do |value|
             logger.register('Event', parse(value), zombie.id)
         end
     end

--- a/modules/browser/browser_fingerprinting/command.js
+++ b/modules/browser/browser_fingerprinting/command.js
@@ -10,17 +10,16 @@ beef.execute(function() {
 	var browser_version = new Array;
 	var dom = document.createElement('b');
 
-	Array.prototype.unique = function() {
-		var o = {}, i, l = this.length, r = [];
-		for(i=0; i<l;i+=1) o[this[i]] = this[i];
-		for(i in o) r.push(o[i]);
-		return r;
-	};
+  function unique(array) {
+    return $.grep(array, function(el, index) {
+      return index === $.inArray(el, array);
+    });
+  }
 
 	parse_browser_details = function() {
 		if (!browser_type.length) browser_type[0] = "unknown";
 		if (!browser_version.length) browser_version[0] = "unknown";
-		beef.net.send("<%= @command_url %>", <%= @command_id %>, "browser_type="+browser_type.unique()+"&browser_version="+browser_version.unique());
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "browser_type="+unique(browser_type)+"&browser_version="+unique(browser_version));
 	};
 
 	// Browser fingerprints // in the form of: "URI","Browser","version(s)"

--- a/modules/browser/hooked_domain/ajax_fingerprint/command.js
+++ b/modules/browser/hooked_domain/ajax_fingerprint/command.js
@@ -69,7 +69,7 @@ beef.execute(function() {
                 }
             }
             if(results.length >0){
-                urls=unique(results).join('||');a
+                urls=unique(results).join('||');
                 beef.net.send("<%= @command_url %>", <%=  @command_id %>, "script_urls="+urls);
             }
             else{

--- a/modules/browser/hooked_domain/ajax_fingerprint/command.js
+++ b/modules/browser/hooked_domain/ajax_fingerprint/command.js
@@ -11,12 +11,12 @@ beef.execute(function() {
      var results = [];
      var urls = "";  
 
-     Array.prototype.unique = function() {
-         var o = {}, i, l = this.length, r = [];
-         for(i=0; i<l;i+=1) o[this[i]] = this[i];
-         for(i in o) r.push(o[i]);
-         return r;
-     };
+    function unique(array) {
+      return $.grep(array, function(el, index) {
+        return index === $.inArray(el, array);
+      });
+    }
+
      // Fingerprints of javascript /ajax libraries . Library Name: Array of common file names 
      
      var fingerprints = {
@@ -69,7 +69,7 @@ beef.execute(function() {
                 }
             }
             if(results.length >0){
-                urls=results.unique().join('||');
+                urls=unique(results).join('||');a
                 beef.net.send("<%= @command_url %>", <%=  @command_id %>, "script_urls="+urls);
             }
             else{

--- a/modules/browser/hooked_domain/get_form_values/command.js
+++ b/modules/browser/hooked_domain/get_form_values/command.js
@@ -25,7 +25,7 @@ beef.execute(function() {
 
 	// return input field info
 	if (input_values.length) {
-		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result='+JSON.stringify(input_values.unique()));
+    beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result='+JSON.stringify(unique(input_values)));
 	// return if no input fields were found
 	} else {
 		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'error=Could not find any inputs fields on '+window.location);


### PR DESCRIPTION
Thanks for submitting a PR! Please fill in this template where appropriate:

## Category

Bug

## Feature/Issue Description

This PR removes a bug that was described in issue [1909](https://github.com/beefproject/beef/issues/1909).

## Describe What Changes 

As per my description of the issue in the issue itself:

> As suggested by **bcoles** I did a bit of digging and found a cleaner jQuery alternative to address the problem that the `Array.prototype.unique` function was solving. 

```javascript
function unique(array) {
    return $.grep(array, function(el, index) {
        return index === $.inArray(el, array);
    });
}
```

> The code snippet shared above by **l0kihardt** should now result in the expected behaviour:

```javascript
let a = [{}, {}, {}];

for(i in a){
    console.log(i);
}

// OUTPUT
0 
1
2
```

## Test Cases

Tests are passing and I haven't noticed any other issues/bugs caused by this change.

## Relevant Wiki Page

N/A
