### PR TITLE
Fix #1851 - Command/request(s) sent to zombie 'undefined' bug

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ beef:
     # Used by both the RESTful API and the Admin interface
     credentials:
         user:   "beef"
-        passwd: "beef1"
+        passwd: "beef"
 
     # Interface / IP restrictions
     restrictions:

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ beef:
     # Used by both the RESTful API and the Admin interface
     credentials:
         user:   "beef"
-        passwd: "beef"
+        passwd: "beef1"
 
     # Interface / IP restrictions
     restrictions:

--- a/extensions/admin_ui/media/javascript/ui/panel/PanelViewer.js
+++ b/extensions/admin_ui/media/javascript/ui/panel/PanelViewer.js
@@ -91,7 +91,7 @@ function locationHashChanged() {
 
   if (id === null) return;
 
-  var zombie = Object.values(beefwui.hooked_browsers).find(hb => hb.session === location_hash('id'));
+  var zombie = Object.values(beefwui.hooked_browsers).find(hb => hb.session === id);
 
   id = id.replace(/[^a-z0-9]/gi, '');
   console.log("Loading hooked browser with ID: " + id);

--- a/extensions/admin_ui/media/javascript/ui/panel/PanelViewer.js
+++ b/extensions/admin_ui/media/javascript/ui/panel/PanelViewer.js
@@ -91,11 +91,13 @@ function locationHashChanged() {
 
   if (id === null) return;
 
+  var zombie = Object.values(beefwui.hooked_browsers).find(hb => hb.session === location_hash('id'));
+
   id = id.replace(/[^a-z0-9]/gi, '');
   console.log("Loading hooked browser with ID: " + id);
   mainPanel.remove(mainPanel.getComponent('current-browser'));
   if(!mainPanel.getComponent('current-browser')) {
-    mainPanel.add(new ZombieTab({session: id}));
+    mainPanel.add(new ZombieTab(zombie));
   }
 
   mainPanel.activate(mainPanel.getComponent('current-browser'));


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
*e.g. Bug, Module, Extension, Core Functionality, Documentation, Tests*
Bug

## Feature/Issue Description
**Q:** _Please give a brief summary of your feature/fix_
**A:** The current release of BeEF master contains a bug in the 'Current Browser' zombie commands status bar. Any request made or command module launched resulted in an error similar to that highlighted in the picture below:

![image](https://user-images.githubusercontent.com/46417690/87011110-d491ae00-c20a-11ea-9739-2b3cc765fb1a.png)

This patch resolves this issue.

![image](https://user-images.githubusercontent.com/46417690/87012635-e1170600-c20c-11ea-93ae-c7f49ad95a2d.png)

**Q:** _Give a technical rundown of what you have changed (if applicable)_
**A:** The data previously passed into the constructor which generates these messages was only being given an object `zombie` which contained the one key `session` whose value was the Session ID for that hooked browser. The status bar was trying to call on that object to give a value for the key `ip`. I've edited the `zombie` object to contain the full context of the hooked browser which is open in the `ZombieMgr` panel. To do this I called on the `beefwui` (Beef Web UI?) API, and filtered for the hooked browser whose Session ID was in the URI fragment (`location_hash('id')`):

```javascript
var zombie = Object.values(beefwui.hooked_browsers).find(hb => hb.session === id);
```

The `location_hash('id')` code is not mine, and was the previous way of identifying the Session ID (see the commit diff) of the hooked browser being examined.

## Test Cases
**Q:** _Describe your test cases, what you have covered and if there are any use cases that still need addressing._
**A:** None written - Admin UI extension test (and all other tests) still pass, and my manual testing of the UI worked :)

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*

N/A