### PR TITLE
Include URI query string in proxied requests

### DIFF
--- a/extensions/proxy/proxy.rb
+++ b/extensions/proxy/proxy.rb
@@ -97,8 +97,10 @@ module BeEF
           tolerant_parser = URI::Parser.new(:UNRESERVED => BeEF::Core::Configuration.instance.get("beef.extension.requester.uri_unreserved_chars"))
           uri = tolerant_parser.parse(url.to_s)
 
+          uri_path_and_qs = uri.query.nil? ? uri.path : "#{uri.path}?#{uri.query}"
+
           # extensions/requester/api/hook.rb parses raw_request to find port and path
-          raw_request = [method, uri.path, version].join(' ') + "\r\n"
+          raw_request = [method, uri_path_and_qs, version].join(' ') + "\r\n"
           content_length = 0
 
           loop do
@@ -127,7 +129,7 @@ module BeEF
               :proto => proto,
               :domain => uri.host,
               :port => uri.port,
-              :path => uri.path,
+              :path => uri_path_and_qs,
               :request_date => Time.now,
               :hooked_browser_id => self.get_tunneling_proxy,
               :allow_cross_domain => "true"


### PR DESCRIPTION
# Category

Bug

# Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Proxied requests with query string params (e.g. https://foo.example/bar?fizz=buzz) were being sent without the query string (i.e. https://foo.example/bar)

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** If the `URI` has a `query` then construct a path that includes the query string

# Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:**

No test cases written. I've done simple testing in the lab only. I'd appreciate a careful look and further testing.

:heavy_check_mark: Proxied requests without a query string work, and are sent without a query string
:heavy_check_mark: Proxied requests with a query string (`?foo`) work, and are sent with the correct query string
:heavy_check_mark: Proxied requests with a query string (`?foo=bar`) work, and are sent with the correct query string

# Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*

N/A
