### PR TITLE
Excluded hooking subnet

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,8 @@ beef:
         # subnet of IP addresses that can connect to the admin UI
         #permitted_ui_subnet: ["127.0.0.1/32", "::1/128"]
         permitted_ui_subnet: ["0.0.0.0/0", "::/0"]
+        # subnet of IP addresses that cannot be hooked by the framework
+        excluded_hooking_subnet: []
         # slow API calls to 1 every  api_attempt_delay  seconds
         api_attempt_delay: "0.05"
 

--- a/core/main/handlers/hookedbrowsers.rb
+++ b/core/main/handlers/hookedbrowsers.rb
@@ -48,13 +48,13 @@ module Handlers
 
       excluded_hooking_subnet = config.get('beef.restrictions.excluded_hooking_subnet')
       unless excluded_hooking_subnet.nil? || excluded_hooking_subnet.empty?
-        found = false
+        excluded_ip_hooked = false
 
         excluded_hooking_subnet.each do |subnet|
-          found = true if IPAddr.new(subnet).include?(request.ip)
+          excluded_ip_hooked = true if IPAddr.new(subnet).include?(request.ip)
         end
 
-        if found
+        if excluded_ip_hooked
           BeEF::Core::Logger.instance.register('Target Range', "Attempted hook from excluded hooking subnet (#{request.ip}) rejected.")
           error 404 
         end

--- a/core/main/handlers/hookedbrowsers.rb
+++ b/core/main/handlers/hookedbrowsers.rb
@@ -33,7 +33,7 @@ module Handlers
       permitted_hooking_subnet = config.get('beef.restrictions.permitted_hooking_subnet')
       if permitted_hooking_subnet.nil? || permitted_hooking_subnet.empty?
         BeEF::Core::Logger.instance.register('Target Range', "Attempted hook from outside of permitted hooking subnet (#{request.ip}) rejected.")
-	error 404
+	      error 404
       end
 
       found = false
@@ -44,6 +44,20 @@ module Handlers
       unless found
         BeEF::Core::Logger.instance.register('Target Range', "Attempted hook from outside of permitted hooking subnet (#{request.ip}) rejected.")
         error 404
+      end
+
+      excluded_hooking_subnet = config.get('beef.restrictions.excluded_hooking_subnet')
+      unless excluded_hooking_subnet.nil? || excluded_hooking_subnet.empty?
+        found = false
+
+        excluded_hooking_subnet.each do |subnet|
+          found = true if IPAddr.new(subnet).include?(request.ip)
+        end
+
+        if found
+          BeEF::Core::Logger.instance.register('Target Range', "Attempted hook from excluded hooking subnet (#{request.ip}) rejected.")
+          error 404 
+        end
       end
 
       # @note get zombie if already hooked the framework


### PR DESCRIPTION
## Category
Core Functionality

## Feature/Issue Description
**Q:** _Please give a brief summary of your feature/fix_

**A:** Alternative PR to @icamys Added excluded_hooking_subnet config option (#1879). There was some logic that made the code a little difficult to interpret, and it did not look like the feedback was going to be addressed. I liked the feature, so made some small changes to make it slightly easier to read. 

**Q:** _Give a technical rundown of what you have changed (if applicable)_

**A:** BeEF currently has functionality to target and only hook a specified set of subnets. This feature is similar in nature, but instead allows a user to specify a set of subnets that they wish to prevent from ever being hooked.

## Test Cases
**Q:** _Describe your test cases, what you have covered and if there are any use cases that still need addressing_

**A:** None written. To write a test case for this we would need to add it to the list of BrowserStack tests (due to the need to somewhat bootstrap BeEF to create and environment to test in). I believe with the instability of that integration <*sigh*>, we should not be adding tests to it in the meantime. As each test runs 5 times, this would increase the likelihood of needing to go through and check for + rerun any false positives on every PR which is already really painful. Once that is resolved (yet another high priority task) this should be added to the myriad of other test cases that need development.

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*

To be added to [Access Controls section of the Configuration Wiki page](https://github.com/beefproject/beef/wiki/Configuration#access-controls):

### Permitted/Excluded Hooking Subnets

The `beef.config.restrictions.permitted_hooking_subnet` and `beef.config.restrictions.excluded_hooking_subnet` values allow granular control over the range of IPs that BeEF will hook. 

Both values take an array of subnets (provided as strings e.g. '0.0.0.0/0' or '::/0').

The `permitted_hooking_subnet` designates an IP range(s) which BeEF may hook. A victim who browses to a page containing the BeEF hook, whose IP is not within this range, will not have the hook injected.

On the other hand `excluded_hooking_subnet` designates an IP range(s) which BeEF may not hook.

A combination of these controls could be used to permit hooking on a /24 range, for example, `192.168.0.0/24`, but specifically exclude hooking a single IP in that range, such as `192.168.0.74`. See the code block below for a demo of how this would look inside your configuration file:

```yaml
restrictions:
    permitted_hooking_subnet: ["192.168.0.0/24"]
    excluded_hooking_subnet: ["192.168.0.74/32"]
```

