### PR TITLE
Fix country_code is null

### DIFF
--- a/extensions/admin_ui/media/javascript/ui/panel/zombiesTreeList.js
+++ b/extensions/admin_ui/media/javascript/ui/panel/zombiesTreeList.js
@@ -488,7 +488,7 @@ try{
 		balloon_text += "Hardware: " + hooked_browser.hw_name;
 		balloon_text += "<br/>";
 
-		if (hooked_browser.country == 'Unknown') {
+		if ( !hooked_browser.country || !hooked_browser.country_code || hooked_browser.country == 'Unknown' ) {
 			balloon_text += " <img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/unknown.png' /> ";
 			balloon_text += "Location: Unknown";
 		} else {
@@ -506,7 +506,7 @@ try{
 		text += "<img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/" + escape(os_icon) + "' /> ";
 		text += "<img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/" + escape(hw_icon) + "' /> ";
 
-		if (hooked_browser.country == 'Unknown') {
+		if ( !hooked_browser.country || !hooked_browser.country_code || hooked_browser.country == 'Unknown' ) {
 			text += "<img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/unknown.png' /> ";
 		} else {
 			text += "<img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/country-squared/" + escape(hooked_browser.country_code.toLowerCase()) + ".svg' /> ";


### PR DESCRIPTION
# Pull Request

Hi, noticed there is a little issue that makes zombies disappear in the console.
https://github.com/beefproject/beef/issues/1712
The issue has been closed, but other people are still facing it.

## Category
Bug in the Admin interface

## Feature/Issue Description

The issue is simple, BeeF doesn't show hooked browser, but it's still logging them, as observable by the image below:
![image](https://user-images.githubusercontent.com/8959898/88342008-84503b00-cd36-11ea-8708-bf035dd400b3.png)

From the web console, it's easy to see that the issue is presenting at the presentation layer (it's a JavaScript file: web_ui_all.js):
![image](https://user-images.githubusercontent.com/8959898/88341886-510dac00-cd36-11ea-9d36-9afa0128b73c.png)

## Technical Background

The code in web_ui_all.js is minified, and the error triggers in the following snippet (notice the same error appears twice in the same file):
```javascript
((c += " <img width='13px' height='13px' class='zombie-tree-icon' src='/ui/media/images/icons/country-squared/" + escape(e.country_code.toLowerCase()) + ".svg' /> "),                      
```

The value `e.country_code` is not null checked, hence causing the error. As we_ui_all.js is a minified file generated on access, modyfing it it's not a solution. The real file affected is `zombiesTreeList.js`.

The fix is trivial, adding a null check to the existing "Unknown" check:
```javascript
if ( !hooked_browser.country || !hooked_browser.country_code || hooked_browser.country == 'Unknown' ) {
	balloon_text += " <img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/unknown.png' /> ";
	balloon_text += "Location: Unknown";
} else {
	balloon_text += " <img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/country-squared/" + escape(hooked_browser.country_code.toLowerCase()) + ".svg' /> ";
	balloon_text += "Location: " + hooked_browser.city + ", " + hooked_browser.country;
}

...

if ( !hooked_browser.country || !hooked_browser.country_code || hooked_browser.country == 'Unknown' ) {
	text += "<img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/unknown.png' /> ";
} else {
	text += "<img width='13px' height='13px' class='zombie-tree-icon' src='<%= @base_path %>/media/images/icons/country-squared/" + escape(hooked_browser.country_code.toLowerCase()) + ".svg' /> ";
}
```
 
## Test Cases

I've tested it arbitrarily setting null values for hooked browsers. They were still appearing in the Admin Console.