### PR TITLE
First fix for the XSSRays

### DIFF
--- a/extensions/xssrays/rest/xssrays.rb
+++ b/extensions/xssrays/rest/xssrays.rb
@@ -122,7 +122,7 @@ module BeEF
           begin
             id = params[:id]
 
-            hooked_browser = HB.where(:session => id).distinct.order(:id)
+            hooked_browser = HB.where(:session => id).distinct.order(:id).first
 
             if hooked_browser.nil?
               print_error "[XSSRAYS] Invalid hooked browser ID"


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
*e.g. Bug*

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** related to #1983, when running XSSRays it fails in a catch for an internal server error. This is due to Ruby trickery that my simple fix resolves. There is likely to be more errors related to this that ill chase down later, however this one resolves this part of it and the specific ticket.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:**  A fun fact about using the where function is that it returns  ActiveRecord::Relation which basically acts like an array. Since its using that to find the record we have to go into it similar to how we would go into a hash that contains an array to grab the record. This is done by adding the .first

see the difference here:
![image](https://user-images.githubusercontent.com/37361441/89147806-2673ec80-d59b-11ea-88c4-e96ef9d21bfa.png)

with the top one, the reference gives the relational error but with the bottom one, it can actually access it.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** Manually testing returns that its running but the results arent returning. Likely to be a similar issue in the code that i will raise a ticket for and run down.

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
Nil
