### PR TITLE
Gemfile: Bump nokogiri version from >= 1.10.8 to >= 1.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'term-ansicolor', :require => 'term/ansicolor'
 gem 'json'
 gem 'rubyzip', '>= 1.2.2'
 gem 'espeak-ruby', '>= 1.0.4' # Text-to-Voice
-gem 'nokogiri', '>= 1.10.8'
+gem 'nokogiri', '>= 1.11.1'
 gem 'rake', '>= 12.3.3'
 gem 'otr-activerecord'
 gem 'sqlite3'


### PR DESCRIPTION
```
Name: nokogiri
Version: 1.10.10
Advisory: CVE-2020-26247
Criticality: Low
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
Title: Nokogiri::XML::Schema trusts input by default, exposing risk of an XXE vulnerability
Solution: upgrade to >= 1.11.0.rc4

Vulnerabilities found!
```

I'm not sure if BeEF is affected by this but it makes sense to enforce use of a newer and non-vulnerable version.

