### PR TITLE
Allow running beef behind reverse proxy with HTTPS

### DIFF
--- a/core/main/server.rb
+++ b/core/main/server.rb
@@ -41,7 +41,7 @@ module BeEF
             'beef_public'   => @configuration.get('beef.http.public'),
             'beef_public_port' => @configuration.get('beef.http.public_port'),
             'beef_hook'     => @configuration.get('beef.http.hook_file'),
-            'beef_proto'    => @configuration.get('beef.http.https.enable') == true ? 'https' : 'http',
+            'beef_proto'    => @configuration.get('beef.http.https.enable') == true || @configuration.get('beef.http.public_port') == '443' ? 'https' : 'http',
             'client_debug'  => @configuration.get('beef.client_debug')
         }
       end


### PR DESCRIPTION
Allow to run beef behind reverse proxy (such as Caddy with automatic HTTPS).
For that you need to set `public_port` in yaml config to 443.

Relevant issues: https://github.com/beefproject/beef/issues/1785

# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Core Functionality

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Allow to run beef behind reverse proxy (such as Caddy with automatic HTTPS)

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** To correctly run Beef behind reverse proxy with automatic HTTPS such as Caddy, you need correct httpproto in `hook.js`. Right now we can only set it to HTTPS if we enable https in `config.yaml`, but that requires manually creating HTTP certs, which is inconvenient and doesn't work well when running behing reverse proxy. 

This change correctly sets httpproto as HTTPS in `hook.js` file when you specify `public_port` to 443

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** I ran it behind reverse proxy with HTTPS and it works

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
