### PR TITLE
renamed the WebCloner model class to align with ActiveRecord syntax

### DIFF
--- a/extensions/social_engineering/models/web_cloner.rb
+++ b/extensions/social_engineering/models/web_cloner.rb
@@ -6,7 +6,7 @@
 module BeEF
   module Core
     module Models
-      class Webcloner < BeEF::Core::Model
+      class WebCloner < BeEF::Core::Model
 
         has_many :interceptors
 

--- a/extensions/social_engineering/web_cloner/web_cloner.rb
+++ b/extensions/social_engineering/web_cloner/web_cloner.rb
@@ -144,7 +144,6 @@ module BeEF
             end
 
             print_info "Mounting cloned page on URL [#{mount}]"
-            byebug
             @http_server.mount("#{mount}", interceptor.new)
             @http_server.remap
 

--- a/extensions/social_engineering/web_cloner/web_cloner.rb
+++ b/extensions/social_engineering/web_cloner/web_cloner.rb
@@ -144,6 +144,7 @@ module BeEF
             end
 
             print_info "Mounting cloned page on URL [#{mount}]"
+            byebug
             @http_server.mount("#{mount}", interceptor.new)
             @http_server.remap
 
@@ -206,7 +207,7 @@ module BeEF
         end
 
         def persist_page(uri, mount)
-          webcloner_db = BeEF::Core::Models::Webcloner.new(
+          webcloner_db = BeEF::Core::Models::WebCloner.new(
               :uri => uri,
               :mount => mount
           )

--- a/spec/beef/extensions/social_engineering_spec.rb
+++ b/spec/beef/extensions/social_engineering_spec.rb
@@ -7,7 +7,8 @@ require 'fileutils'
 RSpec.describe 'BeEF Extension Social Engineering' do
 
   after(:all) do
-    FileUtils.rm_rf(Dir['./extensions/social_engineering/web_cloner/cloned_pages/*'])
+    FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com'])
+    FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com_mod'])
   end
 
   it 'persistence web cloner' do

--- a/spec/beef/extensions/social_engineering_spec.rb
+++ b/spec/beef/extensions/social_engineering_spec.rb
@@ -6,11 +6,6 @@ require 'fileutils'
 
 RSpec.describe 'BeEF Extension Social Engineering' do
 
-  after(:all) do
-    FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com'])
-    FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com_mod'])
-  end
-
   it 'persistence web cloner' do
     expect {
       BeEF::Core::Models::WebCloner.create(uri: "example.com", mount: "/")
@@ -21,5 +16,7 @@ RSpec.describe 'BeEF Extension Social Engineering' do
     expect {
       BeEF::Extension::SocialEngineering::WebCloner.instance.clone_page("https://www.google.com", "/", nil, nil)
     }.to_not raise_error
+    FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com'])
+    FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com_mod'])
   end
 end

--- a/spec/beef/extensions/social_engineering_spec.rb
+++ b/spec/beef/extensions/social_engineering_spec.rb
@@ -1,0 +1,24 @@
+require 'extensions/social_engineering/models/web_cloner'
+require 'extensions/social_engineering/web_cloner/web_cloner'
+require 'extensions/social_engineering/web_cloner/interceptor'
+require 'extensions/social_engineering/models/interceptor'
+require 'fileutils'
+
+RSpec.describe 'BeEF Extension Social Engineering' do
+
+  after(:all) do
+    FileUtils.rm_rf(Dir['./extensions/social_engineering/web_cloner/cloned_pages/*'])
+  end
+
+  it 'persistence web cloner' do
+    expect {
+      BeEF::Core::Models::WebCloner.create(uri: "example.com", mount: "/")
+    }.to_not raise_error
+  end
+
+  it 'clone web page' do
+    expect {
+      BeEF::Extension::SocialEngineering::WebCloner.instance.clone_page("https://www.google.com", "/", nil, nil)
+    }.to_not raise_error
+  end
+end


### PR DESCRIPTION
changed WebCloner name changes in web_cloner.rb
created two tests to support changeswq

# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Extension Defect


## Feature/Issue Description
Issue with persistence of a cloned web site.
Model was not named inline with ActiveRecord syntax and therefore the table could not be found.


## Test Cases
Create a basic model create test, improvement required would be to add a checking expect
Created a test of the entire web cloning functionality, there is an improvement of using the beef auth page instead off google.com
