### PR TITLE
OTR-ActiveRecord update: added to manually call the database connection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rubyzip', '>= 1.2.2'
 gem 'espeak-ruby', '>= 1.0.4' # Text-to-Voice
 gem 'nokogiri', '>= 1.11.1'
 gem 'rake', '>= 12.3.3'
-gem 'otr-activerecord', '~> 1.4.1'
+gem 'otr-activerecord'
 gem 'sqlite3'
 gem 'rubocop', '~> 0.92.0', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rubyzip', '>= 1.2.2'
 gem 'espeak-ruby', '>= 1.0.4' # Text-to-Voice
 gem 'nokogiri', '>= 1.11.1'
 gem 'rake', '>= 12.3.3'
-gem 'otr-activerecord'
+gem 'otr-activerecord', '>= 1.4.2'
 gem 'sqlite3'
 gem 'rubocop', '~> 0.92.0', require: false
 

--- a/beef
+++ b/beef
@@ -167,12 +167,16 @@ end
 ActiveRecord::Base.logger = nil
 OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
 OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database:db_file)
+# otr-activerecord require you to manually establish the connection with the following line
+#Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+  OTR::ActiveRecord.establish_connection!
+end
 # Migrate (if required)
 context = ActiveRecord::Migration.new.migration_context
 if context.needs_migration?
   ActiveRecord::Migrator.new(:up, context.migrations, context.schema_migration).migrate
 end
-
 #
 # @note Extensions may take a moment to load, thus we print out a please wait message
 #

--- a/beef
+++ b/beef
@@ -169,7 +169,7 @@ OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')
 OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database:db_file)
 # otr-activerecord require you to manually establish the connection with the following line
 #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
   OTR::ActiveRecord.establish_connection!
 end
 # Migrate (if required)

--- a/spec/beef/api/auth_rate_spec.rb
+++ b/spec/beef/api/auth_rate_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'BeEF API Rate Limit' do
 		OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database: db_file)
 		# otr-activerecord require you to manually establish the connection with the following line
 		#Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-		if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+		if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
 			OTR::ActiveRecord.establish_connection!
   		end
 		context = ActiveRecord::Migration.new.migration_context

--- a/spec/beef/api/auth_rate_spec.rb
+++ b/spec/beef/api/auth_rate_spec.rb
@@ -43,7 +43,11 @@ RSpec.describe 'BeEF API Rate Limit' do
 		ActiveRecord::Base.logger = nil
 		OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
 		OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database: db_file)
-
+		# otr-activerecord require you to manually establish the connection with the following line
+		#Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+		if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+			OTR::ActiveRecord.establish_connection!
+  		end
 		context = ActiveRecord::Migration.new.migration_context
 		if context.needs_migration?
 		  ActiveRecord::Migrator.new(:up, context.migrations, context.schema_migration).migrate

--- a/spec/beef/core/main/autorun_engine/autorun_engine_spec.rb
+++ b/spec/beef/core/main/autorun_engine/autorun_engine_spec.rb
@@ -48,7 +48,11 @@ RSpec.describe 'AutoRunEngine Test', run_on_browserstack: true do
     ActiveRecord::Base.logger = nil
     OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
     OTR::ActiveRecord.configure_from_hash!(adapter: 'sqlite3', database: db_file)
-
+    # otr-activerecord require you to manually establish the connection with the following line
+    #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+      OTR::ActiveRecord.establish_connection!
+    end
     context = ActiveRecord::Migration.new.migration_context
     ActiveRecord::Migrator.new(:up, context.migrations, context.schema_migration).migrate if context.needs_migration?
 

--- a/spec/beef/core/main/autorun_engine/autorun_engine_spec.rb
+++ b/spec/beef/core/main/autorun_engine/autorun_engine_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'AutoRunEngine Test', run_on_browserstack: true do
     OTR::ActiveRecord.configure_from_hash!(adapter: 'sqlite3', database: db_file)
     # otr-activerecord require you to manually establish the connection with the following line
     #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
       OTR::ActiveRecord.establish_connection!
     end
     context = ActiveRecord::Migration.new.migration_context

--- a/spec/beef/extensions/requester_spec.rb
+++ b/spec/beef/extensions/requester_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'BeEF Extension Requester' do
     OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database:'beef.db')
     # otr-activerecord require you to manually establish the connection with the following line
     #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
       OTR::ActiveRecord.establish_connection!
     end
 # Migrate (if required)

--- a/spec/beef/extensions/requester_spec.rb
+++ b/spec/beef/extensions/requester_spec.rb
@@ -34,7 +34,12 @@ RSpec.describe 'BeEF Extension Requester' do
     ActiveRecord::Base.logger = nil
     OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
     OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database:'beef.db')
-    # Migrate (if required)
+    # otr-activerecord require you to manually establish the connection with the following line
+    #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+      OTR::ActiveRecord.establish_connection!
+    end
+# Migrate (if required)
     context = ActiveRecord::Migration.new.migration_context
     
     

--- a/spec/beef/extensions/websocket_hooked_browser_spec.rb
+++ b/spec/beef/extensions/websocket_hooked_browser_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe 'Browser hooking with Websockets', run_on_browserstack: true do
     ActiveRecord::Base.logger = nil
     OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
     OTR::ActiveRecord.configure_from_hash!(adapter: 'sqlite3', database: db_file)
+    # otr-activerecord require you to manually establish the connection with the following line
+    #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+      OTR::ActiveRecord.establish_connection!
+    end
     context = ActiveRecord::Migration.new.migration_context
     ActiveRecord::Migrator.new(:up, context.migrations, context.schema_migration).migrate if context.needs_migration?
     sleep 2

--- a/spec/beef/extensions/websocket_hooked_browser_spec.rb
+++ b/spec/beef/extensions/websocket_hooked_browser_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Browser hooking with Websockets', run_on_browserstack: true do
     OTR::ActiveRecord.configure_from_hash!(adapter: 'sqlite3', database: db_file)
     # otr-activerecord require you to manually establish the connection with the following line
     #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
       OTR::ActiveRecord.establish_connection!
     end
     context = ActiveRecord::Migration.new.migration_context

--- a/spec/beef/modules/debug/test_beef_debugs_spec.rb
+++ b/spec/beef/modules/debug/test_beef_debugs_spec.rb
@@ -47,7 +47,11 @@ RSpec.describe 'BeEF Debug Command Modules:', run_on_browserstack: true do
     ActiveRecord::Base.logger = nil
     OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
     OTR::ActiveRecord.configure_from_hash!(adapter: 'sqlite3', database: db_file)
-
+    # otr-activerecord require you to manually establish the connection with the following line
+    #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+      OTR::ActiveRecord.establish_connection!
+    end
     context = ActiveRecord::Migration.new.migration_context
     ActiveRecord::Migrator.new(:up, context.migrations, context.schema_migration).migrate if context.needs_migration?
 

--- a/spec/beef/modules/debug/test_beef_debugs_spec.rb
+++ b/spec/beef/modules/debug/test_beef_debugs_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'BeEF Debug Command Modules:', run_on_browserstack: true do
     OTR::ActiveRecord.configure_from_hash!(adapter: 'sqlite3', database: db_file)
     # otr-activerecord require you to manually establish the connection with the following line
     #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+    if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
       OTR::ActiveRecord.establish_connection!
     end
     context = ActiveRecord::Migration.new.migration_context

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,11 @@ CONFIG['key'] = ENV['BROWSERSTACK_ACCESS_KEY'] || ''
 ActiveRecord::Base.logger = nil
 OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')]
 OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database:':memory:')
+# otr-activerecord require you to manually establish the connection with the following line
+#Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
+if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+  OTR::ActiveRecord.establish_connection!
+end
 ActiveRecord::Schema.verbose = false
 context = ActiveRecord::Migration.new.migration_context
 if context.needs_migration?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ OTR::ActiveRecord.migrations_paths = [File.join('core', 'main', 'ar-migrations')
 OTR::ActiveRecord.configure_from_hash!(adapter:'sqlite3', database:':memory:')
 # otr-activerecord require you to manually establish the connection with the following line
 #Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
-if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
+if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('1.4.2')
   OTR::ActiveRecord.establish_connection!
 end
 ActiveRecord::Schema.verbose = false


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Core Functionality / Gem compatibility fix -  Database connection

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** As per OTR-ActiveRecord 2.0.0 they require you to manually establish the database connection which means that the latest gem versions has not been usable. I have added the manual call and also a check to confirm that the version is 2.0.0 or higher as it will bug out on older gem versions. This also includes on the spec files when they are called and should handle.
Relates to:
#2093 #2115 

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** The OTR-ActiveRecord gem requires you to call ``` OTR::ActiveRecord.establish_connection!  ``` when you establish the database connection. I have written lines to check to confirm that the gem version is the required version and then the call is made. It seemed easier to check in code than to deal with people being forced to update their gems. It may be better to do that at a later time but hopefully for now it saved some created github issues. Basically if the Gem is checking if its older than 1.4.2 which was the last version where you did not need to use the call. It might not be needed to do this though. Didn't update the Gemfile lock to the lastest one as it's not needed, didn't see the need to enforce it but raise concerns if you have them.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** This changed the spec helpers, i found it odd that some of the spec files re-built the server and i wasn't able to work out why exactly as they seemed similar. Not in the scope for this though.

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
I intend to have a section written with how it is needed similar to this:
# otr-activerecord require you to manually establish the connection with the following line
#Also a check to confirm that the correct Gem version is installed to require it, likely easier for old systems.
```
 if Gem.loaded_specs['otr-activerecord'].version > Gem::Version.create('2.0')
  OTR::ActiveRecord.establish_connection!
end 
```
