### PR TITLE
Testing: Error running social_engerring_spec

### DIFF
--- a/spec/beef/extensions/social_engineering_spec.rb
+++ b/spec/beef/extensions/social_engineering_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'BeEF Extension Social Engineering' do
 
   it 'clone web page' do
     expect {
+      BeEF::Core::Server.instance.prepare
       BeEF::Extension::SocialEngineering::WebCloner.instance.clone_page("https://www.google.com", "/", nil, nil)
     }.to_not raise_error
     FileUtils.rm(Dir['./extensions/social_engineering/web_cloner/cloned_pages/www.google.com'])


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Bug, Tests

## Feature/Issue Description
As ssen in #2149 there was an bug in the spec social_engerieering_spec.rb

To prevent this bug the BeEF::Core::Server.instance.prepare can be used to prevent @rack_app from being nil allowing the testing to execute and pass
