### PR TITLE
2206 install script error fix

### DIFF
--- a/install
+++ b/install
@@ -101,7 +101,6 @@ install_linux () {
   if [ -z "${Distro}" ] ; then
     fatal "Unable to locate installer for your ${OS} distribution"
   fi
-
   readonly Distro
   info "OS Distribution: ${Distro}"
   info "Installing ${Distro} prerequisite packages..."
@@ -276,7 +275,7 @@ main () {
   echo "#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#"
   echo
 
-  if $GITACTIONS 
+  if [ ! -z ${GITACTIONS:-} ];
   then
     info "Skipping: Running on Github Actions"
   else


### PR DESCRIPTION
Rather than using the code:
https://github.com/beefproject/beef/blob/541933a45fac2dfa3b3caf31319fe83fa0ca29bc/install#L278-L280

I Have added:

```bash
empty="" # Used for confirming GITACTIONS below is set

  if [ ! -z ${GITACTIONS:-} ];
```

Which will return empty if GITACTIONS is not set