### PR TITLE
Fix modules for Metasploit v6.1.10-dev

### DIFF
--- a/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-handler.rb
+++ b/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-handler.rb
@@ -10,7 +10,7 @@ module Handler
 # This module implements the Bind TCP handler placeholder only.
 #
 ###
-module BeEFBind
+module BeefBind
 
 	include Msf::Handler
 
@@ -38,7 +38,7 @@ module BeEFBind
 			[
 				Opt::LPORT(4444),
 				#OptAddress.new('RHOST', [false, 'The target address', '']),
-			], Msf::Handler::BeEFBind)
+			], Msf::Handler::BeefBind)
 	end
 
 	#

--- a/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stage-linux-x86.rb
+++ b/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stage-linux-x86.rb
@@ -5,9 +5,9 @@
 # http://metasploit.com/framework/
 ##
 
-require 'msf/core'
-require 'msf/base/sessions/command_shell'
-require 'msf/base/sessions/command_shell_options'
+#require 'msf/core'
+#require 'msf/base/sessions/command_shell'
+#require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 

--- a/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stage-linux-x86.rb
+++ b/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stage-linux-x86.rb
@@ -5,9 +5,9 @@
 # http://metasploit.com/framework/
 ##
 
-#require 'msf/core'
-#require 'msf/base/sessions/command_shell'
-#require 'msf/base/sessions/command_shell_options'
+require 'msf/core'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 

--- a/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stager-linux-x64.rb
+++ b/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stager-linux-x64.rb
@@ -23,7 +23,7 @@ module MetasploitModule
 			'License'       => BSD_LICENSE,
 			'Platform'      => 'linux',
 			'Arch'          => ARCH_X64,
-			'Handler'       => Msf::Handler::BeEFBind,
+			'Handler'       => Msf::Handler::BeefBind,
 			'Convention'    => 'beef_bind',
 			'Stager'        =>
 				{

--- a/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stager-linux-x86.rb
+++ b/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stager-linux-x86.rb
@@ -23,7 +23,7 @@ module MetasploitModule
 			'License'       => BSD_LICENSE,
 			'Platform'      => 'linux',
 			'Arch'          => ARCH_X86,
-			'Handler'       => Msf::Handler::BeEFBind,
+			'Handler'       => Msf::Handler::BeefBind,
 			'Convention'    => 'beef_bind',
 			'Stager'        =>
 				{

--- a/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stager-windows-x86.rb
+++ b/modules/exploits/beefbind/shellcode_sources/msf/beef_bind-stager-windows-x86.rb
@@ -28,7 +28,7 @@ module MetasploitModule
 			'License'       => BSD_LICENSE,
 			'Platform'      => 'win',
 			'Arch'          => ARCH_X86,
-			'Handler'       => Msf::Handler::BeEFBind,
+			'Handler'       => Msf::Handler::BeefBind,
 			'Convention'    => 'beef_bind',
 			'Stager'        =>
 				{


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Bug

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:**  I have adapted the bind_shell modules for metasploit version 6.1.10-dev.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** Module names have been changed, as metasploit did not recognise the module with capital letters in the name.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:**I started metasploit and msfvenom and it was already detecting the cases. Previously it gave an error and no module was started.

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
