### PR TITLE
Defect: user input in beef script no longer causes docker to error when building and running beef

### DIFF
--- a/beef
+++ b/beef
@@ -57,7 +57,7 @@ if File.exist?("#{$root_dir}git") && BeEF::Core::Console::CommandLine.parse[:upd
         puts '-- BeEF Update Available --'
         print 'Would you like to update to lastest version? y/n: '
         response = gets
-        `git pull && bundle` if response.strip == 'y'
+        `git pull && bundle` if response&.strip == 'y'
       end
     rescue Timeout::Error
       puts "\nUpdate Skipped with input timeout"


### PR DESCRIPTION
https://github.com/beefproject/beef/blob/66257f1cf3a5d99acdd9e1ad94cc1637853549ad/beef#L60
When executing docker run as per instructions, it would fail on response being nil.
I have added a nil guard to prevent error