### PR TITLE
#2249 Added additional grep command to correctly identify arch distro

### DIFF
--- a/install
+++ b/install
@@ -90,7 +90,7 @@ install_linux () {
     Distro='Alpine'
   elif [ -f /etc/os-release ] ; then
     #DISTRO_ID=$(grep ^ID= /etc/os-release | cut -d= -f2-)
-    DISTRO_ID=$(cat /etc/os-release | grep  ID= | grep -v "BUILD" | cut -d= -f2-)
+    DISTRO_ID=$(cat /etc/os-release | grep  ID= | grep -v "BUILD" | grep -v "IMAGE" | cut -d= -f2-)
     if [ "${DISTRO_ID}" = 'kali' ] ; then
       Distro='Kali'
     elif [ "${DISTRO_ID}" = 'arch' ] || [ "${DISTRO_ID}" = 'manjaro' ] ; then


### PR DESCRIPTION
From #2249 Line 93 of install script now includes `grep -v "IMAGE"` to filter out the extra line which may appear.
```
DISTRO_ID=$(cat /etc/os-release | grep  ID= | grep -v "BUILD" | grep -v "IMAGE" | cut -d= -f2-)
```

From: https://www.freedesktop.org/software/systemd/man/os-release.html

IMAGE_ID=

    A lower-case string (no spaces or other characters outside of 0–9, a–z, ".", "_" and "-"), identifying a specific image of the operating system. This is supposed to be used for environments where OS images are prepared, built, shipped and updated as comprehensive, consistent OS images. This field is optional and may not be implemented on all systems, in particularly not on those that are not managed via images but put together and updated from individual packages and on the local system.

    Examples: "IMAGE_ID=vendorx-cashier-system", "IMAGE_ID=netbook-image".

Note: It may be worth rethinking the grep here, as it could be a long grep to remove all potential strings that can appear in that file...