### PR TITLE
Rubocop: Update TargetRubyVersion to 2.7 and enable all NewCops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,8 @@ AllCops:
     - 'tmp/**/*'
     - 'tools/**/*'
     - 'doc/**/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
+  NewCops: enable
 
 Layout/LineLength:
   Enabled: true
@@ -31,48 +32,3 @@ Metrics/CyclomaticComplexity:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# TODO: review these
-Layout/SpaceBeforeBrackets:
-  Enabled: false
-Lint/AmbiguousAssignment:
-  Enabled: false
-Lint/DeprecatedConstants:
-  Enabled: false
-Lint/DuplicateBranch:
-  Enabled: false
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: false
-Lint/EmptyBlock:
-  Enabled: false
-Lint/EmptyClass:
-  Enabled: false
-Lint/LambdaWithoutLiteralBlock:
-  Enabled: false
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: false
-Lint/RedundantDirGlobSort:
-  Enabled: false
-Lint/ToEnumArguments:
-  Enabled: false
-Lint/UnexpectedBlockArity:
-  Enabled: false
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: false
-Style/ArgumentsForwarding:
-  Enabled: false
-Style/CollectionCompact:
-  Enabled: false
-Style/DocumentDynamicEvalDefinition:
-  Enabled: false
-Style/EndlessMethod:
-  Enabled: false
-Style/HashExcept:
-  Enabled: false
-Style/NegatedIfElseCondition:
-  Enabled: false
-Style/NilLambda:
-  Enabled: false
-Style/RedundantArgument:
-  Enabled: false
-Style/SwapValues:
-  Enabled: false


### PR DESCRIPTION
BeEF uses Ruby 2.7. Ruby 2.6 is no longer supported.

Enable `NewCops` for now. If it is a problem we can disable it in the future. However, if any new rules are problematic, we should simply explicitly disable them instead.

