### PR TITLE
Bump minimum required Ruby version from 2.5 to 2.7

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -21,9 +21,9 @@ Or cloning the Git repository from Github:
 Prerequisites
 --------------
 
-BeEF requires Ruby 2.5+.
+BeEF requires Ruby 2.7+.
 
-If your operating system package manager does not support Ruby version 2.5,
+If your operating system package manager does not support Ruby version 2.7,
 you can add the brightbox ppa repository for the latest version of Ruby:
 
   $ sudo apt-add-repository -y ppa:brightbox/ruby-ng

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requirements
 ------------
 
 * Operating System: Mac OSX 10.5.0 or higher / modern Linux. Note: Windows is not supported.
-* [Ruby](http://ruby-lang.org): 2.5 or newer
+* [Ruby](http://ruby-lang.org): 2.7 or newer
 * [SQLite](http://sqlite.org): 3.x
 * [Node.js](https://nodejs.org): 10 or newer
 * The gems listed in the Gemfile: https://github.com/beefproject/beef/blob/master/Gemfile

--- a/beef
+++ b/beef
@@ -12,11 +12,12 @@
 $VERBOSE = nil
 
 #
-# @note Version check to ensure BeEF is running Ruby 2.5+
+# @note Version check to ensure BeEF is running Ruby 2.7+
 #
-if RUBY_VERSION < '2.5'
+min_ruby_version = '2.7'
+if RUBY_VERSION < min_ruby_version
   puts
-  puts "Ruby version #{RUBY_VERSION} is no longer supported. Please upgrade to Ruby version 2.5 or later."
+  puts "Ruby version #{RUBY_VERSION} is no longer supported. Please upgrade to Ruby version #{min_ruby_version} or later."
   puts
   exit 1
 end


### PR DESCRIPTION
Ruby 2.5 is end of life.

We've already described Ruby 2.7 as the minimum version elsewhere in the code base.
