### PR TITLE
Treat core configuration file load failure as fatal

### DIFF
--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -31,7 +31,8 @@ module BeEF
           @@config = config
         rescue StandardError => e
           print_error "Fatal Error: cannot load configuration file '#{config}' : #{e.message}"
-          print_error e.backtrace
+          print_more e.backtrace
+          exit(1)
         end
 
         @@instance = self
@@ -41,13 +42,8 @@ module BeEF
       # @param [String] file YAML file to be loaded
       # @return [Hash] YAML formatted hash
       def load(file)
-        return nil unless File.exist? file
-
-        raw = File.read file
-        YAML.safe_load raw
-      rescue StandardError => e
-        print_debug "Unable to load configuration file '#{file}' : #{e.message}"
-        print_error e.backtrace
+        return nil unless File.exist?(file)
+        YAML.safe_load(File.binread(file))
       end
 
       #


### PR DESCRIPTION
Fixes #2333

# Before

```
# ./beef 
[ 7:37:03][!] Fatal Error: cannot load configuration file '/root/Desktop/beef/./config.yaml' : uninitialized class variable @@instance in BeEF::Core::Configuration
Did you mean?  instance_of?
[ 7:37:03][!] ["/root/Desktop/beef/core/main/configuration.rb:16:in `instance'", "/root/Desktop/beef/core/ruby/print.rb:38:in `print_debug'", "/root/Desktop/beef/core/main/configuration.rb:49:in `rescue in load'", "/root/Desktop/beef/core/main/configuration.rb:43:in `load'", "/root/Desktop/beef/core/main/configuration.rb:28:in `initialize'", "./beef:83:in `new'", "./beef:83:in `<main>'"]
Traceback (most recent call last):
	4: from ./beef:91:in `<main>'
	3: from /root/Desktop/beef/core/main/configuration.rb:201:in `get'
	2: from /root/Desktop/beef/core/main/configuration.rb:201:in `inject'
	1: from /root/Desktop/beef/core/main/configuration.rb:201:in `each'
/root/Desktop/beef/core/main/configuration.rb:202:in `block in get': undefined method `[]' for nil:NilClass (NoMethodError)
```

# After

```
# ./beef 
[ 7:31:18][!] Fatal Error: cannot load configuration file '/root/Desktop/beef/./config.yaml' : (<unknown>): did not find expected key while parsing a block mapping at line 37 column 9
[ 7:31:18]    |   /var/lib/gems/2.7.0/gems/psych-4.0.3/lib/psych.rb:455:in `parse'
[ 7:31:18]    |   /var/lib/gems/2.7.0/gems/psych-4.0.3/lib/psych.rb:455:in `parse_stream'
[ 7:31:18]    |   /var/lib/gems/2.7.0/gems/psych-4.0.3/lib/psych.rb:399:in `parse'
[ 7:31:18]    |   /var/lib/gems/2.7.0/gems/psych-4.0.3/lib/psych.rb:324:in `safe_load'
[ 7:31:18]    |   /root/Desktop/beef/core/main/configuration.rb:46:in `load'
[ 7:31:18]    |   /root/Desktop/beef/core/main/configuration.rb:28:in `initialize'
[ 7:31:18]    |   ./beef:83:in `new'
[ 7:31:18]    |_  ./beef:83:in `<main>'
```
