### PR TITLE
Fixed bug when response_data is empty when http.response_data.length is <= 100K

### DIFF
--- a/extensions/requester/rest/requester.rb
+++ b/extensions/requester/rest/requester.rb
@@ -229,9 +229,13 @@ module BeEF
         def response2hash(http)
           response_data = ''
 
-          if !http.response_data.nil? && (http.response_data.length > (1024 * 100)) # more thank 100K
-            response_data = http.response_data[0..(1024 * 100)]
-            response_data += "\n<---------- Response Data Truncated---------->"
+          if !http.response_data.nil?
+            if (http.response_data.length > (1024 * 100)) # more thank 100K
+              http.response_data = http.response_data[0..(1024 * 100)]
+              http.response_data += "\n<---------- Response Data Truncated---------->"
+            end
+
+            response_data = http.response_data
           end
 
           response_headers = ''

--- a/extensions/requester/rest/requester.rb
+++ b/extensions/requester/rest/requester.rb
@@ -229,13 +229,13 @@ module BeEF
         def response2hash(http)
           response_data = ''
 
-          if !http.response_data.nil?
-            if (http.response_data.length > (1024 * 100)) # more thank 100K
-              http.response_data = http.response_data[0..(1024 * 100)]
-              http.response_data += "\n<---------- Response Data Truncated---------->"
+          unless http.response_data.nil?
+            if (http.response_data.length > (1024 * 100)) # more than 100K
+              response_data = http.response_data[0..(1024 * 100)]
+              response_data += "\n<---------- Response Data Truncated---------->"
+            else
+              response_data = http.response_data
             end
-
-            response_data = http.response_data
           end
 
           response_headers = ''


### PR DESCRIPTION
## Category
Bug

## Feature/Issue Description
Previously `requester` extension has not worked correctly. It has really initiated sending the request by Browser, and correctly saved the result to DB. But it did not showed the result in web panel: `Response Body` was empty.

The bug caused by impropper `if `statement and introduced in commit https://github.com/beefproject/beef/commit/aa7a6f9e644ef8da9006a28379f0193df00dba99

## WARNING
This is the first time I am using ruby. So, please, make sure I did everything right.