### PR TITLE
WebRTC: Rename Rtc model classes to align with ActiveRecord syntax

### DIFF
--- a/extensions/webrtc/api/hook.rb
+++ b/extensions/webrtc/api/hook.rb
@@ -17,7 +17,7 @@ module BeEF
 
           include BeEF::Core::Handlers::Modules::BeEFJS
 
-          # If the Rtcsignal table contains requests that need to be sent (has_sent = waiting), retrieve
+          # If the RtcSignal table contains requests that need to be sent (has_sent = waiting), retrieve
           # and send them to the hooked browser.
           # Don't forget, these are signalling messages for a peer, so we don't check that the request
           # is for the hooked_browser_id, but the target
@@ -29,7 +29,7 @@ module BeEF
             rtcmanagementoutput = []
 
             # Get all RTCSignals for this browser
-            BeEF::Core::Models::Rtcsignal.where(:target_hooked_browser_id => hb.id, :has_sent => "waiting").each { |h|
+            BeEF::Core::Models::RtcSignal.where(:target_hooked_browser_id => hb.id, :has_sent => "waiting").each { |h|
               # output << self.requester_parse_db_request(h)
               rtcsignaloutput << h.signal
               h.has_sent = "sent"
@@ -37,7 +37,7 @@ module BeEF
             }
 
             # Get all RTCManagement messages for this browser
-            BeEF::Core::Models::Rtcmanage.where(:hooked_browser_id => hb.id, :has_sent => "waiting").each {|h|
+            BeEF::Core::Models::RtcManage.where(:hooked_browser_id => hb.id, :has_sent => "waiting").each {|h|
               rtcmanagementoutput << h.message
               h.has_sent = "sent"
               h.save

--- a/extensions/webrtc/handlers.rb
+++ b/extensions/webrtc/handlers.rb
@@ -12,7 +12,7 @@ module BeEF
       #
       class SignalHandler
 
-        R = BeEF::Core::Models::Rtcsignal
+        R = BeEF::Core::Models::RtcSignal
         Z = BeEF::Core::Models::HookedBrowser
 
         def initialize(data)

--- a/extensions/webrtc/models/rtcmanage.rb
+++ b/extensions/webrtc/models/rtcmanage.rb
@@ -9,34 +9,34 @@ module Models
   #
   # Table stores the queued up JS commands for managing the client-side webrtc logic.
   #
-  class Rtcmanage < BeEF::Core::Model
+  class RtcManage < BeEF::Core::Model
   
     # Starts the RTCPeerConnection process, establishing a WebRTC connection between the caller and the receiver
     def self.initiate(caller, receiver, verbosity = false)
       stunservers = BeEF::Core::Configuration.instance.get("beef.extension.webrtc.stunservers")
       turnservers = BeEF::Core::Configuration.instance.get("beef.extension.webrtc.turnservers")
 
-      # Add the beef.webrtc.start() JavaScript call into the Rtcmanage table - this will be picked up by the browser on next hook.js poll
+      # Add the beef.webrtc.start() JavaScript call into the RtcManage table - this will be picked up by the browser on next hook.js poll
       # This is for the Receiver
-      r = BeEF::Core::Models::Rtcmanage.new(:hooked_browser_id => receiver, :message => "beef.webrtc.start(0,#{caller},JSON.stringify(#{turnservers}),JSON.stringify(#{stunservers}),#{verbosity});")
+      r = BeEF::Core::Models::RtcManage.new(:hooked_browser_id => receiver, :message => "beef.webrtc.start(0,#{caller},JSON.stringify(#{turnservers}),JSON.stringify(#{stunservers}),#{verbosity});")
       r.save!
       
       # This is the same beef.webrtc.start() JS call, but for the Caller
-      r = BeEF::Core::Models::Rtcmanage.new(:hooked_browser_id => caller, :message => "beef.webrtc.start(1,#{receiver},JSON.stringify(#{turnservers}),JSON.stringify(#{stunservers}),#{verbosity});")
+      r = BeEF::Core::Models::RtcManage.new(:hooked_browser_id => caller, :message => "beef.webrtc.start(1,#{receiver},JSON.stringify(#{turnservers}),JSON.stringify(#{stunservers}),#{verbosity});")
       r.save!
     end
 
     # Advises a browser to send an RTCDataChannel message to its peer
     # Similar to the initiate method, this loads up a JavaScript call to the beefrtcs[peerid].sendPeerMsg() function call
     def self.sendmsg(from, to, message)
-      r = BeEF::Core::Models::Rtcmanage.new(:hooked_browser_id => from, :message => "beefrtcs[#{to}].sendPeerMsg('#{message}');")
+      r = BeEF::Core::Models::RtcManage.new(:hooked_browser_id => from, :message => "beefrtcs[#{to}].sendPeerMsg('#{message}');")
       r.save!
     end
 
     # Gets the browser to run the beef.webrtc.status() JavaScript function
     # This JS function will return it's values to the /rtcmessage handler
     def self.status(id)
-      r = BeEF::Core::Models::Rtcmanage.new(:hooked_browser_id => id, :message => "beef.webrtc.status(#{id});")
+      r = BeEF::Core::Models::RtcManage.new(:hooked_browser_id => id, :message => "beef.webrtc.status(#{id});")
       r.save!
     end
 

--- a/extensions/webrtc/models/rtcsignal.rb
+++ b/extensions/webrtc/models/rtcsignal.rb
@@ -9,7 +9,7 @@ module Models
   #
   # Table stores the webrtc signals from a hooked_browser, directed to a target_hooked_browser
   #
-  class Rtcsignal < BeEF::Core::Model
+  class RtcSignal < BeEF::Core::Model
 
     belongs_to :hooked_browser
 

--- a/extensions/webrtc/rest/webrtc.rb
+++ b/extensions/webrtc/rest/webrtc.rb
@@ -85,9 +85,9 @@ module BeEF
           end
 
           if verbose.to_s =~ (/^(true|t|yes|y|1)$/i)
-            BeEF::Core::Models::Rtcmanage.initiate(fromhb.to_i, tohb.to_i, true)
+            BeEF::Core::Models::RtcManage.initiate(fromhb.to_i, tohb.to_i, true)
           else
-            BeEF::Core::Models::Rtcmanage.initiate(fromhb.to_i, tohb.to_i)
+            BeEF::Core::Models::RtcManage.initiate(fromhb.to_i, tohb.to_i)
           end
 
           r = BeEF::Core::Models::Rtcstatus.new(
@@ -139,7 +139,7 @@ module BeEF
         get '/status/:id' do
           id = params[:id]
 
-          BeEF::Core::Models::Rtcmanage.status(id.to_i)
+          BeEF::Core::Models::RtcManage.status(id.to_i)
           result = {}
           result['success'] = true
           result.to_json
@@ -313,7 +313,7 @@ module BeEF
           if [fromhb, tohb, message].include?(nil)
             result['success'] = false
           else
-            BeEF::Core::Models::Rtcmanage.sendmsg(fromhb.to_i, tohb.to_i, message)
+            BeEF::Core::Models::RtcManage.sendmsg(fromhb.to_i, tohb.to_i, message)
             result['success'] = true
           end
 
@@ -436,7 +436,7 @@ module BeEF
 
           # Finally queue the message in the RTC queue for submission
           # from the from browser to the to browser
-          BeEF::Core::Models::Rtcmanage.sendmsg(fromhb.to_i, tohb.to_i, msg)
+          BeEF::Core::Models::RtcManage.sendmsg(fromhb.to_i, tohb.to_i, msg)
 
           result = {}
           result['success'] = true


### PR DESCRIPTION
Fixes #2508.
