### PR TITLE
Add support for the SuSE family in the installer

### DIFF
--- a/install
+++ b/install
@@ -6,7 +6,9 @@
 #
 
 set -euo pipefail
-IFS=$'\n\t'
+NORMIFS=$IFS
+SCRIFS=$'\n\t'
+IFS=$SCRIFS
 
 info() { echo -e "\\033[1;36m[INFO]\\033[0m  $*"; }
 warn() { echo -e "\\033[1;33m[WARNING]\\033[0m  $*"; }
@@ -89,7 +91,9 @@ install_linux() {
 			Distro='Kali'
 		elif [ "${DISTRO_ID}" = 'arch' ] || [ "${DISTRO_ID}" = 'artix' ] || [ "${DISTRO_ID}" = 'manjaro' ] || [ "${DISTRO_ID}" = 'blackarch' ] || [ "${DISTRO_ID}" = 'arcolinux' ]; then
 			Distro='Arch'
-		fi
+		elif cat /etc/os-release | grep -Eqi '^ID.*suse'; then
+			Distro='SuSE'
+		fi # Usually, I would do this very differently (. /etc/os-release ...), but keeping to the style.
 	fi
 
 	if [ -z "${Distro}" ]; then
@@ -109,6 +113,16 @@ install_linux() {
 		fi
 	elif [ "${Distro}" = "RedHat" ]; then
 		sudo yum install -y git make gcc openssl-devel gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs
+	elif [ "${Distro}" = "SuSE" ]; then
+		IFS=$NORMIFS
+		intpkg=""
+		nodejsver=nodejs16
+		rpm --quiet -q nodejs18 && nodejsver=""                                                                          # having NodeJS 18 installed should mean NodeJS 16 is not needed
+		for i in git make gcc libopenssl-devel gcc-c++ patch libreadline6 readline6-devel libz1 zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite3-devel $nodejsver; do
+			rpm --quiet -q $i || intpkg="$intpkg $i"
+		done
+		[ "$intpkg" ] && sudo zypper -n install -l $intpkg
+		IFS=$SCRIFS
 	elif [ "${Distro}" = "blackPanther" ]; then
 		installing --auto git make gcc openssl-devel gcc-c++ patch readline-devel zlib-devel yaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs sudo
 	elif [ "${Distro}" = "Arch" ]; then


### PR DESCRIPTION
Extension to installer (Core Functionality?)

Added support for SuSE derivatives (such as opensuse etc) in the install script

The install script uses zypper to install needed packages after checking if they are already there (if they are, the install is skipped). Because Opensuse has multiple versions of nodejs, it installs nodejs16 since that is more likely to be there on the other (older) distros, but it allows nodejs18 to satisfy it if it is already installed.

Tested on OpenSuSE Tumbeweed version 20220930

