### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,7 +134,7 @@ task :beef_start => 'beef' do
   config = YAML.safe_load(File.read('./config.yaml'))
   config['beef']['credentials']['user'] = test_user
   config['beef']['credentials']['passwd'] = test_pass
-  Dir.mkdir('tmp') unless Dir.exists?('tmp')
+  Dir.mkdir('tmp') unless Dir.exist?('tmp')
   File.open(@beef_config_file, 'w') { |f| YAML.dump(config, f) }
 
   # set the environment creds -- in case we're using bad_fred

--- a/beef
+++ b/beef
@@ -185,7 +185,7 @@ db_file = config.get('beef.database.file')
 if BeEF::Core::Console::CommandLine.parse[:resetdb]
   print_info 'Resetting the database for BeEF.'
   begin
-    File.delete(db_file) if File.exists?(db_file)
+    File.delete(db_file) if File.exist?(db_file)
   rescue => e
     print_error("Could not remove '#{db_file}' database file: #{e.message}")
     exit(1)

--- a/extensions/console/lib/rbreadline.rb
+++ b/extensions/console/lib/rbreadline.rb
@@ -6486,7 +6486,7 @@ module RbReadline
    #     `%' for character special devices
    #     `#' for block special devices
    def stat_char(filename)
-      return nil if !File.exists?(filename)
+      return nil if !File.exist?(filename)
 
       return '/' if File.directory?(filename)
       return '%' if File.chardev?(filename)

--- a/extensions/console/lib/sedTmoz0z
+++ b/extensions/console/lib/sedTmoz0z
@@ -6486,7 +6486,7 @@ module RbReadline
    #     `%' for character special devices
    #     `#' for block special devices
    def stat_char(filename)
-      return nil if !File.exists?(filename)
+      return nil if !File.exist?(filename)
 
       return '/' if File.directory?(filename)
       return '%' if File.chardev?(filename)

--- a/spec/beef/api/auth_rate_spec.rb
+++ b/spec/beef/api/auth_rate_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'BeEF API Rate Limit' do
 
 		if BeEF::Core::Console::CommandLine.parse[:resetdb]
 			print_info 'Resetting the database for BeEF.'
-			File.delete(db_file) if File.exists?(db_file)
+			File.delete(db_file) if File.exist?(db_file)
 		end
 
 		# Load up DB and migrate if necessary

--- a/tools/chrome_extensions_exploitation/webstore_uploader/webstore_upload.rb
+++ b/tools/chrome_extensions_exploitation/webstore_uploader/webstore_upload.rb
@@ -43,19 +43,19 @@ else
 end
 ACTION = action
 
-if !File.exists?(EXT_ZIP_NAME)
+if !File.exist?(EXT_ZIP_NAME)
     puts "[-] Error: #{EXT_ZIP_NAME} does not exist"
     help()
 end
 
-if ARGV[2] != nil and File.exists?(ARGV[2])
+if ARGV[2] != nil and File.exist?(ARGV[2])
     DESCRIPTION = File.new(ARGV[2]).read()
     puts "[*] Using description from #{ARGV[2]}"
 else
     DESCRIPTION = ""
 end
 
-if ARGV[3] != nil and File.exists?(ARGV[3])
+if ARGV[3] != nil and File.exist?(ARGV[3])
     SCREENSHOT_NAME = ARGV[3]
     puts "[*] Using screenshot from #{SCREENSHOT_NAME}"
 end


### PR DESCRIPTION
`File.exists?` was deprecated in Ruby 2.1.0 and has been removed in the Ruby 3.2.0.

* https://bugs.ruby-lang.org/issues/17391
* https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/