### PR TITLE
[WIP] Fixing CLI-handling

### DIFF
--- a/beef
+++ b/beef
@@ -39,6 +39,16 @@ $root_dir = File.join(File.expand_path(File.dirname(File.realpath(__FILE__))), '
 $:.unshift($root_dir)
 $home_dir = File.expand_path("#{Dir.home}/.beef/", __FILE__).freeze
 
+
+#
+# @note Parse beef command line arguments before requiring loader.
+# The loader will require bundler default arguments, bringing in Sinatra which will
+# then hog the Option Parsing. Thus, we need to parse before that.
+#
+require 'core/main/console/commandline'
+BeEF::Core::Console::CommandLine.parse
+
+
 #
 # @note Require core loader
 #
@@ -48,8 +58,8 @@ require 'timeout'
 #
 # @note Ask user if they would like to update beef
 #
-if File.exist?("#{$root_dir}git") && BeEF::Core::Console::CommandLine.parse[:update_disabled] == false
-  if BeEF::Core::Console::CommandLine.parse[:update_auto] == true
+if File.exist?("#{$root_dir}git") && BeEF::Core::Console::CommandLine.get_options[:update_disabled] == false
+  if BeEF::Core::Console::CommandLine.get_options[:update_auto] == true
     print 'Checking latest BeEF repository and updating'
     `git pull && bundle`
   elsif `git rev-parse master` != `git rev-parse origin/master`
@@ -79,10 +89,10 @@ end
 #
 # @note Initialize the Configuration object. Loads a different config.yaml if -c flag was passed.
 #
-if BeEF::Core::Console::CommandLine.parse[:ext_config].empty?
+if BeEF::Core::Console::CommandLine.get_options[:ext_config].empty?
   config = BeEF::Core::Configuration.new("#{$root_dir}/config.yaml")
 else
-  config = BeEF::Core::Configuration.new("#{BeEF::Core::Console::CommandLine.parse[:ext_config]}")
+  config = BeEF::Core::Configuration.new("#{BeEF::Core::Console::CommandLine.get_options[:ext_config]}")
 end
 
 #
@@ -105,12 +115,12 @@ end
 #
 # @note Check if port and WebSocket port need to be updated from command line parameters
 #
-unless BeEF::Core::Console::CommandLine.parse[:port].empty?
-  config.set('beef.http.port', BeEF::Core::Console::CommandLine.parse[:port])
+unless BeEF::Core::Console::CommandLine.get_options[:port].empty?
+  config.set('beef.http.port', BeEF::Core::Console::CommandLine.get_options[:port])
 end
 
-unless BeEF::Core::Console::CommandLine.parse[:ws_port].empty?
-  config.set('beef.http.websocket.port', BeEF::Core::Console::CommandLine.parse[:ws_port])
+unless BeEF::Core::Console::CommandLine.get_options[:ws_port].empty?
+  config.set('beef.http.websocket.port', BeEF::Core::Console::CommandLine.get_options[:ws_port])
 end
 
 #
@@ -150,7 +160,7 @@ require 'core/bootstrap'
 #
 # @note Prints the BeEF ascii art if the -a flag was passed
 #
-if BeEF::Core::Console::CommandLine.parse[:ascii_art] == true
+if BeEF::Core::Console::CommandLine.get_options[:ascii_art] == true
   BeEF::Core::Console::Banners.print_ascii_art
 end
 
@@ -182,7 +192,7 @@ Socket.do_not_reverse_lookup = true
 #
 db_file = config.get('beef.database.file')
 # @note Resets the database if the -x flag was passed
-if BeEF::Core::Console::CommandLine.parse[:resetdb]
+if BeEF::Core::Console::CommandLine.get_options[:resetdb]
   print_info 'Resetting the database for BeEF.'
   begin
     File.delete(db_file) if File.exist?(db_file)

--- a/core/ruby/print.rb
+++ b/core/ruby/print.rb
@@ -36,7 +36,7 @@ end
 # @note This function will only print messages if the debug flag is set to true
 def print_debug(s)
   config = BeEF::Core::Configuration.instance
-  return unless config.get('beef.debug') || BeEF::Core::Console::CommandLine.parse[:verbose]
+  return unless config.get('beef.debug') || BeEF::Core::Console::CommandLine.get_options[:verbose]
 
   puts Time.now.localtime.strftime('[%k:%M:%S]') + '[>]' + ' ' + s.to_s
   BeEF.logger.debug s.to_s

--- a/extensions/metasploit/api.rb
+++ b/extensions/metasploit/api.rb
@@ -28,7 +28,7 @@ module BeEF
 
             msf_module_config = {}
             path = "#{$root_dir}/#{BeEF::Core::Configuration.instance.get('beef.extension.metasploit.path')}/msf-exploits.cache"
-            if !BeEF::Core::Console::CommandLine.parse[:resetdb] && File.exist?(path)
+            if !BeEF::Core::Console::CommandLine.get_options[:resetdb] && File.exist?(path)
               print_debug 'Attempting to use Metasploit exploits cache file'
               raw = File.read(path)
               begin

--- a/spec/beef/api/auth_rate_spec.rb
+++ b/spec/beef/api/auth_rate_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'BeEF API Rate Limit' do
 		print_info "Loading database"
 		db_file = @config.get('beef.database.file')
 
-		if BeEF::Core::Console::CommandLine.parse[:resetdb]
+		if BeEF::Core::Console::CommandLine.get_options[:resetdb]
 			print_info 'Resetting the database for BeEF.'
 			File.delete(db_file) if File.exist?(db_file)
 		end


### PR DESCRIPTION
(Starting with) fixing beef cli option handling. Fixes #2174 
Note that this is WIP, I'm opening this to get some feedback on how this should be handled exactly.

## Category
Core Functionality

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Beef options were not part of the `--help` before and not clearly communicated.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** The problem seems to pertain to Sinatra. Since some extensions use Sinatra, it is required from `loader.rb` (by requiring the bundle defaults). From then on, Sinatra basically hogs the command line parsing, parsing `--help`and then exiting. A few key issues:
- I couldn't find much on how to best solve this. It seems Sinatra provides little options here. The only approach I could think of so far was to basically parse before Sinatra and then "hand over".
- Inevitably, this means we can't catch invalid options. We could hard-code Sinatra options to check, but if they ever change this would break.
- Collisions are also hard to detect. I am guessing that for the port option, it is even desired to share. For others, it might not be?
- I'm still not sure whether this actually works, i.e. whether Sinatra is properly parsing the remaining options. I tried to stipulate an error by passing garbage, but it didn't work. They are either not checking the argument content on parsing or I am still missing something.

## Result

With these changes, we would at least see all the command line options being printed when running `./beef --help`, i.e.

```bash
Usage: beef [options]
    -x, --reset                      Reset the database
    -v, --verbose                    Display debug information
    -a, --ascii-art                  Prints BeEF ascii art
    -c, --config FILE                Specify configuration file to load (instead of ./config.yaml)
    -p, --port PORT                  Change the default BeEF listening port
    -w, --wsport WS_PORT             Change the default BeEF WebSocket listening port
        --update-disable             Skips update
        --update-auto                Automatic update with no prompt
    -h, --help                       Prints this help

Sinatra webapp options:
Usage: beef [options]
    -p port                          set the port (default is 4567)
    -s server                        specify rack server/handler
    -q                               turn on quiet mode (default is off)
    -x                               turn on the mutex lock (default is off)
    -e env                           set the environment (default is development)
    -o addr                          set the host (default is (env == 'development' ? 'localhost' : '0.0.0.0'))
```


If anyone has a better idea on handling this, I'd be happy to hear and improve this. I hope I didn't miss anything too obvious :)