### PR TITLE
Improved credential handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ node_modules/
 # Generated files
 out/
 doc/rdoc/
+

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,3 @@ node_modules/
 # Generated files
 out/
 doc/rdoc/
-

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'rake', '~> 13.0'
 gem 'otr-activerecord', '~> 2.1', '>= 2.1.2'
 gem 'sqlite3', '~> 1.6', '>= 1.6.1'
 gem 'rubocop', '~> 1.48.1', require: false
-gem 'bcrypt'
+gem 'bcrypt', '~> 3.1.18'
 
 # Geolocation support
 group :geoip do

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'rake', '~> 13.0'
 gem 'otr-activerecord', '~> 2.1', '>= 2.1.2'
 gem 'sqlite3', '~> 1.6', '>= 1.6.1'
 gem 'rubocop', '~> 1.48.1', require: false
+gem 'bcrypt'
 
 # Geolocation support
 group :geoip do

--- a/beef
+++ b/beef
@@ -133,9 +133,8 @@ unless config.get("beef.credentials")
 
   # Either password or its hash must be specified
   raise "Must specify a password or its bcrypt hash "\
-        "(either via config.yaml or BEEF_PASSWD/BEEF_PWHASH env variables" \
-        unless passwd = ENV["BEEF_PASSWD"] || passwd_hash = ENV["BEEF_PWHASH"]
-
+        "(either via config.yaml or BEEF_PASSWD/BEEF_PWHASH env variables." \
+        unless (passwd = ENV["BEEF_PASSWD"]) || (passwd_hash = ENV["BEEF_PWHASH"])
 
   # Store env values in config -- allows upcoming code to act as if config
   # was populated correctly.
@@ -145,10 +144,23 @@ unless config.get("beef.credentials")
 end
 
 #
+# @note Passed hash must confirm to bcrypt format. When passing the hash on the command line,
+# forgetting to escape e.g. dollar signs $ can lead to this messing up. We warn the user to
+# avoid confusion.
+#
+if (passwd_hash = config.get("beef.credentials.bcrypt_pw_hash")) \
+  && (not BCrypt::Password.valid_hash?(passwd_hash))
+  print_error "ERROR -- Invalid Hash found. \n"\
+              " HINT    : Make sure special characters in hash are escaped or wrapped in single quote.\n"\
+              " EXAMPLE : BEEF_USER=beef BEEF_PWHASH='$2a$12$......' ./beef "
+  exit 1
+end
+
+#
 # @note Exit on default password.
 #
 if config.get("beef.credentials.passwd").eql?("beef") \
-  || (passwd_hash = config.get("beef.credentials.bcrypt_pw_hash") && BCrypt::Password.new(passwd_hash) == "beef") \
+  || (passwd_hash = config.get("beef.credentials.bcrypt_pw_hash") && (BCrypt::Password.new(passwd_hash) == "beef")) \
 
   print_error "ERROR: Default password in use!"
   print_more "Change password and potential hashes (beef.credentials in config.yaml or corresponding environment variables)"
@@ -165,8 +177,8 @@ if passwd = config.get("beef.credentials.passwd")
   # actually match
   raise "Password and its bcrypt hash were specified but did not match. " \
         "Check password and hash or specify only one of the two." \
-        if specified_hash = config.get("beef.credentials.bcrypt_pw_hash") \
-          && specified_hash == passwd_hash
+        if (specified_hash = config.get("beef.credentials.bcrypt_pw_hash")) \
+          && (specified_hash == passwd_hash)
 
   # Make sure hash is stored but password is not.
   config.set("beef.credentials.bcrypt_pw_hash", passwd_hash)

--- a/beef
+++ b/beef
@@ -120,13 +120,57 @@ unless BeEF::Core::Configuration.instance.validate
   exit 1
 end
 
+
 #
-# @note Exit on default credentials
+# If no credentials are present, try reading from env
 #
-if config.get("beef.credentials.user").eql?('beef') && config.get("beef.credentials.passwd").eql?('beef')
-  print_error "ERROR: Default username and password in use!"
-  print_more "Change the beef.credentials.passwd in config.yaml"
+unless config.get("beef.credentials")
+  puts "No credentials set in config.yaml; Reading from env ..."
+
+  # User must be specified
+  raise "Must specify user either in config or BEEF_USER environment variable" \
+        unless user = ENV["BEEF_USER"]
+
+  # Either password or its hash must be specified
+  raise "Must specify a password or its bcrypt hash "\
+        "(either via config.yaml or BEEF_PASSWD/BEEF_PWHASH env variables" \
+        unless passwd = ENV["BEEF_PASSWD"] || passwd_hash = ENV["BEEF_PWHASH"]
+
+
+  # Store env values in config -- allows upcoming code to act as if config
+  # was populated correctly.
+  config.set("beef.credentials.user", user)
+  config.set("beef.credentials.passwd", passwd)
+  config.set("beef.credentials.bcrypt_pw_hash", passwd_hash)
+end
+
+#
+# @note Exit on default password.
+#
+if config.get("beef.credentials.passwd").eql?("beef") \
+  || (passwd_hash = config.get("beef.credentials.bcrypt_pw_hash") && BCrypt::Password.new(passwd_hash) == "beef") \
+
+  print_error "ERROR: Default password in use!"
+  print_more "Change password and potential hashes (beef.credentials in config.yaml or corresponding environment variables)"
   exit 1
+end
+
+#
+# @note Make sure only password hash is stored
+#
+if passwd = config.get("beef.credentials.passwd")
+  passwd_hash = BCrypt::Password.create(passwd)
+
+  # Sanity check: If both password and a hash were specified, they should
+  # actually match
+  raise "Password and its bcrypt hash were specified but did not match. " \
+        "Check password and hash or specify only one of the two." \
+        if specified_hash = config.get("beef.credentials.bcrypt_pw_hash") \
+          && specified_hash == passwd_hash
+
+  # Make sure hash is stored but password is not.
+  config.set("beef.credentials.bcrypt_pw_hash", passwd_hash)
+  config.clear("beef.credentials.passwd")
 end
 
 #

--- a/beef
+++ b/beef
@@ -178,7 +178,7 @@ if passwd = config.get("beef.credentials.passwd")
   raise "Password and its bcrypt hash were specified but did not match. " \
         "Check password and hash or specify only one of the two." \
         if (specified_hash = config.get("beef.credentials.bcrypt_pw_hash")) \
-          && (specified_hash == passwd_hash)
+          && (BCrypt::Password.new(specified_hash) != passwd)
 
   # Make sure hash is stored but password is not.
   config.set("beef.credentials.bcrypt_pw_hash", passwd_hash)

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ beef:
     credentials:
         user:   "beef"
         passwd: "beef"
-        # Instead of a password, you may also use a bcrypt hash of it
+        # Instead of a password, you may also use a bcrypt hash of it.
         #bcrypt_pw_hash: ""
 
     # Interface / IP restrictions

--- a/config.yaml
+++ b/config.yaml
@@ -16,9 +16,14 @@ beef:
 
     # Credentials to authenticate in BeEF.
     # Used by both the RESTful API and the Admin interface
+    # NOTE: This section can be removed and be replaced by the usage of environment
+    #   variables BEEF_USER, BEEF_PASSWD and BEEF_BEEF_PWHASH.
+    #   This way, you can share your config without sharing sensitive information.
     credentials:
         user:   "beef"
         passwd: "beef"
+        # Instead of a password, you may also use a bcrypt hash of it
+        #bcrypt_pw_hash: ""
 
     # Interface / IP restrictions
     restrictions:

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ beef:
     # NOTE: This section can be removed and be replaced by the usage of environment
     #   variables BEEF_USER, BEEF_PASSWD and BEEF_BEEF_PWHASH.
     #   This way, you can share your config without sharing sensitive information.
+    #   Config.yaml takes precedence over environment variables.
     credentials:
         user:   "beef"
         passwd: "beef"

--- a/core/loader.rb
+++ b/core/loader.rb
@@ -15,6 +15,7 @@ require 'msgpack'
 
 Bundler.require(:default)
 
+require 'bcrypt'
 require 'cgi'
 require 'yaml'
 require 'singleton'

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -60,11 +60,6 @@ module BeEF
           return
         end
 
-        if @config['beef']['credentials'].nil?
-          print_error "Configuration file is malformed: 'beef.credentials' is nil"
-          return
-        end
-
         if @config['beef']['http'].nil?
           print_error "Configuration file is malformed: 'beef.http' is nil"
           return

--- a/core/main/configuration.rb
+++ b/core/main/configuration.rb
@@ -74,6 +74,18 @@ module BeEF
           return
         end
 
+        # Make sure that, if credentials are given, a user as well as a password or hash are present.
+        unless (not self.get("beef.credentials")) \
+          || (self.get("beef.credentials.user") && (self.get("beef.credentials.passwd") || self.get("beef.credentials.bcrypt_pw_hash")))
+
+          # Specify allowed config format
+          print_error "ERROR: Invalid Config. Config must either:"
+          print_more " - Not contain a 'credentials' member at all."
+          print_more " - Contain 'credentials.user' and 'credentials.passwd'."
+          print_more " - Contain 'credentials.user' and 'credentials.bcrypt_pw_hash'."
+          return
+        end
+
         true
       end
 

--- a/core/main/rest/handlers/admin.rb
+++ b/core/main/rest/handlers/admin.rb
@@ -52,7 +52,7 @@ module BeEF
           request.body.rewind
           begin
             data = JSON.parse request.body.read
-            if data['username'].eql?(config.get('beef.credentials.user')) && data['password'].eql?(config.get('beef.credentials.passwd'))
+            if data['username'].eql?(config.get('beef.credentials.user')) && (BCrypt::Password.new(config.get('beef.credentials.bcrypt_pw_hash') == data['password']))
               return {
                 'success' => true,
                 'token' => config.get('beef.api_token').to_s

--- a/extensions/admin_ui/controllers/authentication/authentication.rb
+++ b/extensions/admin_ui/controllers/authentication/authentication.rb
@@ -57,7 +57,9 @@ module BeEF
                                                     ->(time) { @session.set_auth_timestamp(time) })
 
             # check username and password
-            unless username.eql?(config.get('beef.credentials.user')) && password.eql?(config.get('beef.credentials.passwd'))
+            unless username.eql?(config.get('beef.credentials.user')) && (BCrypt::Password.new(config.get('beef.credentials.bcrypt_pw_hash')) == password)
+              BeEF::Core::Logger.instance.register('Authentication', "#{ua_ip} has failed to authenticate in the application.")
+
               BeEF::Core::Logger.instance.register('Authentication', "User with ip #{ua_ip} has failed to authenticate in the application.")
               return
             end

--- a/extensions/admin_ui/controllers/authentication/authentication.rb
+++ b/extensions/admin_ui/controllers/authentication/authentication.rb
@@ -58,8 +58,6 @@ module BeEF
 
             # check username and password
             unless username.eql?(config.get('beef.credentials.user')) && (BCrypt::Password.new(config.get('beef.credentials.bcrypt_pw_hash')) == password)
-              BeEF::Core::Logger.instance.register('Authentication', "#{ua_ip} has failed to authenticate in the application.")
-
               BeEF::Core::Logger.instance.register('Authentication', "User with ip #{ua_ip} has failed to authenticate in the application.")
               return
             end

--- a/spec/beef/modules/debug/test_beef_debugs_spec.rb
+++ b/spec/beef/modules/debug/test_beef_debugs_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'BeEF Debug Command Modules:', run_on_browserstack: true do
     print_info 'Resetting the database for BeEF.'
     File.delete(db_file) if File.exist?(db_file)
     @username = @config.get('beef.credentials.user')
-    @password = @config.get('beef.credentials.passwd')
+    @pw_hash = @config.get('beef.credentials.bcrypt_pw_hash')
 
     # Load BeEF extensions and modules
     # Always load Extensions, as previous changes to the config from other tests may affect


### PR DESCRIPTION
- Added environment variables for fallback of admin user and password
- Added capability to specify hash instead of cleartext passwords
- Avoid storing passwords in running beef instance; instead compare hashes

# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Core Functionality

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** I added two fallback methods of credential specification.
    - Instead of specifying credentials in config.yaml, users may now opt to use environment variables.
    - Instead of using a password, they may also directly specify a bcrypt hash instead (works
       for both variants, config and env vars)
       
   I also modified the "default" credential check to never allow the password "beef".
   The password is now also not stored in the config instance anymore. Instead, only the hash is stored
   and used for comparison.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** Made it so that appropriate env variables are read into config and cleared password. Introduced bcrypt gem to allow for proper hashing.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:**

## Wiki Page
I believe the error message and comment in the config suffice, probably. If anything, one could update the recommendations. This change isn't breaking anyway though.