### PR TITLE
AutorunEngine: Cleanup, rename REST routes, use Core::Models in REST API

### DIFF
--- a/arerules/alert.json
+++ b/arerules/alert.json
@@ -1,9 +1,5 @@
 {"name": "Display an alert",
   "author": "mgeeky",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "alert_dialog",
       "condition": null,

--- a/arerules/coinhive_miner.json
+++ b/arerules/coinhive_miner.json
@@ -1,9 +1,5 @@
 {"name": "Start CoinHive JavaScript miner",
   "author": "bcoles",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "coinhive_miner",
       "condition": null,

--- a/arerules/confirm_close_tab.json
+++ b/arerules/confirm_close_tab.json
@@ -1,9 +1,5 @@
 {"name": "Confirm Close Tab",
   "author": "mgeeky",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "confirm_close_tab",
       "condition": null,

--- a/arerules/ff_osx_extension-dropper.json
+++ b/arerules/ff_osx_extension-dropper.json
@@ -2,7 +2,6 @@
   "name": "Firefox Extension Dropper",
   "author": "antisnatchor",
   "browser": "FF",
-  "browser_version": "ALL",
   "os": "OSX",
   "os_version": ">= 10.8",
   "modules": [{

--- a/arerules/get_cookie.json
+++ b/arerules/get_cookie.json
@@ -1,10 +1,6 @@
 {
   "name": "Get Cookie",
   "author": "@benichmt1",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_cookie",
       "condition": null,

--- a/arerules/ie_win_htapowershell.json
+++ b/arerules/ie_win_htapowershell.json
@@ -2,7 +2,6 @@
   "name": "HTA PowerShell",
   "author": "antisnatchor",
   "browser": "IE",
-  "browser_version": "ALL",
   "os": "Windows",
   "os_version": ">= 7",
   "modules": [

--- a/arerules/lan_cors_scan.json
+++ b/arerules/lan_cors_scan.json
@@ -1,9 +1,6 @@
 {"name": "LAN CORS Scan",
   "author": "bcoles",
   "browser": ["FF", "C"],
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/lan_cors_scan_common.json
+++ b/arerules/lan_cors_scan_common.json
@@ -1,9 +1,5 @@
 {"name": "LAN CORS Scan (Common IPs)",
   "author": "bcoles",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "cross_origin_scanner_cors",
       "condition": null,

--- a/arerules/lan_fingerprint.json
+++ b/arerules/lan_fingerprint.json
@@ -1,9 +1,6 @@
 {"name": "LAN Fingerprint",
   "author": "bcoles",
   "browser": ["FF", "C"],
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/lan_fingerprint_common.json
+++ b/arerules/lan_fingerprint_common.json
@@ -1,9 +1,5 @@
 {"name": "LAN Fingerprint (Common IPs)",
   "author": "antisnatchor",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "internal_network_fingerprinting",
       "condition": null,

--- a/arerules/lan_flash_scan.json
+++ b/arerules/lan_flash_scan.json
@@ -1,9 +1,6 @@
 {"name": "LAN Flash Scan",
   "author": "bcoles",
   "browser": ["FF", "C"],
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/lan_flash_scan_common.json
+++ b/arerules/lan_flash_scan_common.json
@@ -1,9 +1,6 @@
 {"name": "LAN Flash Scan (Common IPs)",
   "author": "bcoles",
   "browser": ["FF", "C"],
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "cross_origin_scanner_flash",
       "condition": null,

--- a/arerules/lan_http_scan.json
+++ b/arerules/lan_http_scan.json
@@ -1,9 +1,6 @@
 {"name": "LAN HTTP Scan",
   "author": "bcoles",
   "browser": ["FF", "C"],
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/lan_http_scan_common.json
+++ b/arerules/lan_http_scan_common.json
@@ -1,9 +1,5 @@
 {"name": "LAN HTTP Scan (Common IPs)",
   "author": "bcoles",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_http_servers",
       "condition": null,

--- a/arerules/lan_ping_sweep.json
+++ b/arerules/lan_ping_sweep.json
@@ -1,9 +1,6 @@
 {"name": "LAN Ping Sweep",
   "author": "bcoles",
   "browser": "FF",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/lan_ping_sweep_common.json
+++ b/arerules/lan_ping_sweep_common.json
@@ -1,9 +1,6 @@
 {"name": "LAN Ping Sweep (Common IPs)",
   "author": "bcoles",
   "browser": "FF",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "ping_sweep",
       "condition": null,

--- a/arerules/lan_port_scan.json
+++ b/arerules/lan_port_scan.json
@@ -1,9 +1,5 @@
 {"name": "LAN Port Scan",
   "author": "aburro & aussieklutz",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/lan_sw_port_scan.json
+++ b/arerules/lan_sw_port_scan.json
@@ -1,9 +1,5 @@
 {"name": "LAN SW Port Scan",
   "author": "aburro & aussieklutz",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "get_internal_ip_webrtc",
       "condition": null,

--- a/arerules/man_in_the_browser.json
+++ b/arerules/man_in_the_browser.json
@@ -1,9 +1,5 @@
 {"name": "Perform Man-In-The-Browser",
   "author": "mgeeky",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "man_in_the_browser",
       "condition": null,

--- a/arerules/raw_javascript.json
+++ b/arerules/raw_javascript.json
@@ -1,10 +1,6 @@
 {
   "name": "Raw JavaScript",
   "author": "wade@bindshell.net",
-  "browser": "ALL",
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "raw_javascript",
       "condition": null,

--- a/arerules/record_snapshots.json
+++ b/arerules/record_snapshots.json
@@ -1,9 +1,5 @@
 {"name": "Collects multiple snapshots of the webpage within Same-Origin",
   "author": "mgeeky",
-  "browser": ["FF", "C", "O", "IE", "S"],
-  "browser_version": "ALL",
-  "os": "ALL",
-  "os_version": "ALL",
   "modules": [
     {"name": "spyder_eye",
       "condition": null,

--- a/arerules/win_fake_malware.json
+++ b/arerules/win_fake_malware.json
@@ -2,10 +2,7 @@
 {
   "name": "Windows Fake Malware",
   "author": "bcoles",
-  "browser": "ALL",
-  "browser_version": "ALL",
   "os": "Windows",
-  "os_version": "ALL",
   "modules": [
     {
       "name": "blockui",

--- a/core/main/handlers/browserdetails.rb
+++ b/core/main/handlers/browserdetails.rb
@@ -28,11 +28,13 @@ module BeEF
 
           # validate hook session value
           session_id = get_param(@data, 'beefhook')
+
           print_debug "[INIT] Processing Browser Details for session #{session_id}"
           unless BeEF::Filters.is_valid_hook_session_id?(session_id)
-            (err_msg 'session id is invalid'
-             return)
+            err_msg 'session id is invalid'
+            return
           end
+
           hooked_browser = HB.where(session: session_id).first
           return unless hooked_browser.nil? # browser is already registered with framework
 
@@ -567,7 +569,7 @@ module BeEF
 
           # check if any ARE rules shall be triggered only if the channel is != WebSockets (XHR). If the channel
           # is WebSockets, then ARe rules are triggered after channel is established.
-          BeEF::Core::AutorunEngine::Engine.instance.run(zombie.id, browser_name, browser_version, os_name, os_version) unless config.get('beef.http.websocket.enable')
+          BeEF::Core::AutorunEngine::Engine.instance.find_and_run_all_matching_rules_for_zombie(zombie.id) unless config.get('beef.http.websocket.enable')
         end
 
         def get_param(query, key)

--- a/core/main/models/legacybrowseruseragents.rb
+++ b/core/main/models/legacybrowseruseragents.rb
@@ -10,14 +10,13 @@ module BeEF
       # Objects stores known 'legacy' browser User Agents.
       #
       # This table is used to determine if a hooked browser is a 'legacy' 
-      # browser and therefore which version of the hook file to generate and use
+      # browser.
       #
       # TODO: make it an actual table
       #
       module LegacyBrowserUserAgents
         def self.user_agents
           [
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0'
           ]
         end
       end

--- a/core/main/network_stack/websocket/websocket.rb
+++ b/core/main/network_stack/websocket/websocket.rb
@@ -24,6 +24,8 @@ module BeEF
         MOUNTS = BeEF::Core::Server.instance.mounts
 
         def initialize
+          return unless @@config.get('beef.websocket.enable')
+
           secure = @@config.get('beef.http.websocket.secure')
 
           # @note Start a WSS server socket
@@ -110,11 +112,7 @@ module BeEF
                       next
                     end
 
-                    browser_name    = BeEF::Core::Models::BrowserDetails.get(hb_session, 'browser.name')
-                    browser_version = BeEF::Core::Models::BrowserDetails.get(hb_session, 'browser.version')
-                    os_name = BeEF::Core::Models::BrowserDetails.get(hb_session, 'host.os.name')
-                    os_version = BeEF::Core::Models::BrowserDetails.get(hb_session, 'host.os.version')
-                    BeEF::Core::AutorunEngine::Engine.instance.run(hooked_browser.id, browser_name, browser_version, os_name, os_version)
+                    BeEF::Core::AutorunEngine::Engine.instance.find_and_run_all_matching_rules_for_zombie(hooked_browser.id)
 
                     next
                   end

--- a/tools/rest_api_examples/autorun
+++ b/tools/rest_api_examples/autorun
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+# browser-details - Example BeEF RESTful API script
+# Retrieves all Autorun rules, adds a rule, runs it on all online browsers, then deletes it
+# Refer to the wiki for info: https://github.com/beefproject/beef/wiki/BeEF-RESTful-API
+##
+require 'rest-client'
+require 'json'
+require 'optparse'
+require 'pp'
+require './lib/string' # colored strings
+require './lib/print'  # print wrappers
+require './lib/beef_rest_api'
+
+if ARGV.length == 0
+  puts "#{$0}:"
+  puts "|  Example BeEF RESTful API script"
+  puts "|  Use --help for help"
+  puts "|_ Use verbose mode (-v) and debug mode (-d) for more output"
+  exit 1
+end
+
+# API config
+proto = 'http'
+host = '127.0.0.1'
+port = '3000'
+user = 'beef'
+pass = 'beef'
+
+# Command line options
+@debug = false
+@verbose = false
+OptionParser.new do |opts|
+  opts.on('-h', '--help', 'Shows this help screen') do
+    puts opts
+    exit 1
+  end
+  opts.on('--host HOST', "Set BeEF host (default: #{host})") do |h|
+    host = h
+  end
+  opts.on('--port PORT', "Set BeEF port (default: #{port})") do |p|
+    port = p
+  end
+  opts.on('--user USERNAME', "Set BeEF username (default: #{user})") do |u|
+    user = u
+  end
+  opts.on('--pass PASSWORD', "Set BeEF password (default: #{pass})") do |p|
+    pass = p
+  end
+  opts.on('--ssl', 'Use HTTPS') do
+    proto = 'https'
+  end
+  opts.on('-v', '--verbose', 'Enable verbose output') do
+    @verbose = true
+  end
+  opts.on('-d', '--debug', 'Enable debug output') do
+    @debug = true
+  end
+end.parse!
+
+@api = BeefRestAPI.new proto, host, port, user, pass
+
+# Retrieve the RESTful API token
+print_status "Authenticating to: #{proto}://#{host}:#{port}"
+@api.auth
+
+# Retrieve BeEF version
+@api.version
+
+print_status("Retrieving Autorun rules")
+rules = @api.autorun_rules
+print_debug(rules)
+
+print_status("Adding a rule")
+
+res = @api.autorun_add_rule({
+  "name": "Say Hello",
+  "author": "REST API",
+  "modules": [
+    {
+      "name": "alert_dialog",
+      "options": {
+        "text":"Hello from REST API"
+      }
+    }
+  ],
+  "execution_order": [0],
+  "execution_delay": [0]
+})
+
+print_debug(res)
+
+rule_id = res['rule_id']
+
+unless rule_id.nil?
+  print_status "Running rule #{rule_id} on all browsers"
+  res = @api.autorun_run_rule_on_all_browsers(rule_id)
+  print_debug(res)
+
+  print_status("Deleting rule #{rule_id}")
+  res = @api.autorun_delete_rule(rule_id)
+  print_debug(res)
+end


### PR DESCRIPTION
Replace `BeEF::Core::AutorunEngine::Models` with `BeEF::Core::Models`. Fixes #2019. Shoutout to @Squigilum for fixing this in #2020 which was unfortunately never merged.

---

Rename the REST API URL routes to be more sensible. Request all rules with `/api/autorun/rules`. No more of this `/api/autorun/rule/list/all` nonsense.

```
get '/rules'
get '/rule/:rule_id'
get '/run/:rule_id'
get '/run/:rule_id/:hb_id'
post '/rule/add'
delete '/rule/:rule_id'
```

---

Add REST API samples for the Autorun REST API.

---

Massive refactor of the Autorun Engine. It is still terrible but now the code is readable.

---

Remove `os` / `browser` properties with redundant 'ALL' values from sample ARE rules. `ALL` is implied and does not need to be defined.
