### PR TITLE
Remove PhishingFrenzy integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -124,13 +124,6 @@ beef:
         # GeoLite2 City database created by MaxMind, available from https://www.maxmind.com
         database: '/usr/share/GeoIP/GeoLite2-City.mmdb'
 
-    # Integration with PhishingFrenzy
-    # If enabled BeEF will try to get the UID parameter value from the hooked URI, as this is used by PhishingFrenzy
-    # to uniquely identify the victims. In this way you can easily associate phishing emails with hooked browser.
-    integration:
-        phishing_frenzy:
-            enable: false
-
     # You may override default extension configuration parameters here
     # Note: additional experimental extensions are available in the 'extensions' directory
     #       and can be enabled via their respective 'config.yaml' file

--- a/core/main/client/browser.js
+++ b/core/main/client/browser.js
@@ -4331,24 +4331,6 @@ beef.browser = {
         if (has_wmp) details['browser.capabilities.wmp'] = has_wmp;
         if (has_vlc) details['browser.capabilities.vlc'] = has_vlc;
 
-        var pf_integration = "<%= @phishing_frenzy_enable %>";
-        if (pf_integration) {
-            var pf_param = "uid";
-            var pf_victim_uid = "";
-            var location_search = window.location.search.substring(1);
-            var params = location_search.split('&');
-            for (var i = 0; i < params.length; i++) {
-                var param_entry = params[i].split('=');
-                if (param_entry[0] == pf_param) {
-                    pf_victim_uid = param_entry[1];
-                    details['PhishingFrenzyUID'] = pf_victim_uid;
-                    break;
-                }
-            }
-        } else {
-            details['PhishingFrenzyUID'] = "N/A";
-        }
-
         return details;
     },
 

--- a/core/main/handlers/browserdetails.rb
+++ b/core/main/handlers/browserdetails.rb
@@ -546,17 +546,6 @@ module BeEF
             err_msg "Invalid value for hardware.screen.touchenabled returned from the hook browser's initial connection."
           end
 
-          if config.get('beef.integration.phishing_frenzy.enable')
-            # get and store the browser plugins
-            victim_uid = get_param(@data['results'], 'PhishingFrenzyUID')
-            print_debug "PhishingFrenzy victim UID is #{victim_uid}"
-            if BeEF::Filters.alphanums_only?(victim_uid)
-              BD.set(session_id, 'PhishingFrenzyUID', victim_uid)
-            else
-              err_msg "Invalid PhishingFrenzy Victim UID returned from the hook browser's initial connection."
-            end
-          end
-
           # log a few info of newly hooked zombie in the console
           print_info "New Hooked Browser [id:#{zombie.id}, ip:#{zombie.ip}, browser:#{browser_name}-#{browser_version}, os:#{os_name}-#{os_version}], hooked domain [#{log_zombie_domain}:#{log_zombie_port}]"
 

--- a/core/main/handlers/modules/beefjs.rb
+++ b/core/main/handlers/modules/beefjs.rb
@@ -100,9 +100,6 @@ module BeEF
               hook_session_config['websocket_sec_port'] = config.get('beef.http.websocket.secure_port')
             end
 
-            # @note Set if PhishingFrenzy integration is enabled
-            hook_session_config['phishing_frenzy_enable'] = config.get('beef.integration.phishing_frenzy.enable') if config.get('beef.integration.phishing_frenzy.enable')
-
             # @note populate place holders in the beef_js string and set the response body
             eruby = Erubis::FastEruby.new(beef_js)
             @hook = eruby.evaluate(hook_session_config)

--- a/core/main/handlers/modules/legacybeefjs.rb
+++ b/core/main/handlers/modules/legacybeefjs.rb
@@ -100,9 +100,6 @@ module BeEF
               hook_session_config['websocket_sec_port'] = config.get('beef.http.websocket.secure_port')
             end
 
-            # @note Set if PhishingFrenzy integration is enabled
-            hook_session_config['phishing_frenzy_enable'] = config.get('beef.integration.phishing_frenzy.enable') if config.get('beef.integration.phishing_frenzy.enable')
-
             # @note populate place holders in the beef_js string and set the response body
             eruby = Erubis::FastEruby.new(beef_js)
             @hook = eruby.evaluate(hook_session_config)

--- a/core/main/handlers/modules/multistagebeefjs.rb
+++ b/core/main/handlers/modules/multistagebeefjs.rb
@@ -100,9 +100,6 @@ module BeEF
               hook_session_config['websocket_sec_port'] = config.get('beef.http.websocket.secure_port')
             end
 
-            # @note Set if PhishingFrenzy integration is enabled
-            hook_session_config['phishing_frenzy_enable'] = config.get('beef.integration.phishing_frenzy.enable') if config.get('beef.integration.phishing_frenzy.enable')
-
             # @note populate place holders in the beef_js string and set the response body
             eruby = Erubis::FastEruby.new(beef_js)
             @hook = eruby.evaluate(hook_session_config)

--- a/core/main/rest/handlers/hookedbrowsers.rb
+++ b/core/main/rest/handlers/hookedbrowsers.rb
@@ -100,32 +100,6 @@ module BeEF
         end
 
         #
-        # @note this is basically the same call as /api/hooks, but returns different data structured in arrays rather than objects.
-        # Useful if you need to query the API via jQuery.dataTable < 1.10 which is currently used in PhishingFrenzy
-        #
-        get '/pf/online' do
-          online_hooks = hbs_to_array(BeEF::Core::Models::HookedBrowser.where('lastseen >= ?', (Time.new.to_i - 15)))
-
-          output = {
-            'aaData' => online_hooks
-          }
-          output.to_json
-        end
-
-        #
-        # @note this is basically the same call as /api/hooks, but returns different data structured in arrays rather than objects.
-        # Useful if you need to query the API via jQuery.dataTable < 1.10 which is currently used in PhishingFrenzy
-        #
-        get '/pf/offline' do
-          offline_hooks = hbs_to_array(BeEF::Core::Models::HookedBrowser.where('lastseen <= ?', (Time.new.to_i - 15)))
-
-          output = {
-            'aaData' => offline_hooks
-          }
-          output.to_json
-        end
-
-        #
         # @note Get all the hooked browser details (plugins enabled, technologies enabled, cookies)
         #
         get '/:session' do
@@ -197,38 +171,6 @@ module BeEF
             'country' => details.get(hb.session, 'location.country'),
             'country_code' => details.get(hb.session, 'location.country.isocode')
           }
-        end
-
-        # this is used in the 'get '/pf'' restful api call
-        def hbs_to_array(hbs)
-          hooked_browsers = []
-          hbs.each do |hb|
-            details = BeEF::Core::Models::BrowserDetails
-            # @todo what does the below TODO comment mean? why do we care about the client side view inside a controller?
-            # TODO: jQuery.dataTables needs fixed array indexes, add emptry string if a value is blank
-
-            pfuid = details.get(hb.session, 'PhishingFrenzyUID').nil? ? 'n/a' : details.get(hb.session, 'PhishingFrenzyUID')
-            bname = details.get(hb.session, 'browser.name').nil? ? 'n/a' : details.get(hb.session, 'browser.name')
-            bversion = details.get(hb.session, 'browser.version').nil? ? 'n/a' : details.get(hb.session, 'browser.version')
-            bplugins = details.get(hb.session, 'browser.plugins').nil? ? 'n/a' : details.get(hb.session, 'browser.plugins')
-
-            hooked_browsers << [
-              hb.id,
-              hb.ip,
-              pfuid,
-              bname,
-              bversion,
-              details.get(hb.session, 'host.os.name'),
-              details.get(hb.session, 'browser.platform'),
-              details.get(hb.session, 'browser.language'),
-              bplugins,
-              details.get(hb.session, 'location.city'),
-              details.get(hb.session, 'location.country'),
-              details.get(hb.session, 'location.latitude'),
-              details.get(hb.session, 'location.longitude')
-            ]
-          end
-          hooked_browsers
         end
       end
     end

--- a/docs/browser.js.html
+++ b/docs/browser.js.html
@@ -4350,24 +4350,6 @@ beef.browser = {
         if (has_wmp) details['browser.capabilities.wmp'] = has_wmp;
         if (has_vlc) details['browser.capabilities.vlc'] = has_vlc;
 
-        var pf_integration = "&lt;%= @phishing_frenzy_enable %>";
-        if (pf_integration) {
-            var pf_param = "uid";
-            var pf_victim_uid = "";
-            var location_search = window.location.search.substring(1);
-            var params = location_search.split('&amp;');
-            for (var i = 0; i &lt; params.length; i++) {
-                var param_entry = params[i].split('=');
-                if (param_entry[0] == pf_param) {
-                    pf_victim_uid = param_entry[1];
-                    details['PhishingFrenzyUID'] = pf_victim_uid;
-                    break;
-                }
-            }
-        } else {
-            details['PhishingFrenzyUID'] = "N/A";
-        }
-
         return details;
     },
 

--- a/spec/support/assets/config_new.yaml
+++ b/spec/support/assets/config_new.yaml
@@ -128,13 +128,6 @@ beef:
         enable: true
         database: '/opt/GeoIP/GeoLite2-City.mmdb'
 
-    # Integration with PhishingFrenzy
-    # If enabled BeEF will try to get the UID parameter value from the hooked URI, as this is used by PhishingFrenzy
-    # to uniquely identify the victims. In this way you can easily associate phishing emails with hooked browser.
-    integration:
-        phishing_frenzy:
-            enable: false
-
     # You may override default extension configuration parameters here
     # Note: additional experimental extensions are available in the 'extensions' directory
     #       and can be enabled via their respective 'config.yaml' file

--- a/spec/support/assets/config_old.yaml
+++ b/spec/support/assets/config_old.yaml
@@ -121,13 +121,6 @@ beef:
         enable: true
         database: '/opt/GeoIP/GeoLite2-City.mmdb'
 
-    # Integration with PhishingFrenzy
-    # If enabled BeEF will try to get the UID parameter value from the hooked URI, as this is used by PhishingFrenzy
-    # to uniquely identify the victims. In this way you can easily associate phishing emails with hooked browser.
-    integration:
-        phishing_frenzy:
-            enable: false
-
     # You may override default extension configuration parameters here
     # Note: additional experimental extensions are available in the 'extensions' directory
     #       and can be enabled via their respective 'config.yaml' file


### PR DESCRIPTION
PhishingFrenzy appears to be a dead project. The website is down and the repository has not been updated in 5+ years.

The integration was originally added by a PhishingFrenzy developer and consists of two parts:

* Rather than PhishingFrenzy using BeEF's APIs, REST API calls were added specifically for use by PhishingFrenzy. These API calls are not used anywhere else and add additional maintenance burden.
* Additional code was added to the browser hook to grab the PhishingFrenzy session ID from `window.location.search` and store it in the database. If hte PhishingFrenzy project is still alive and wants to continue integrating with BeEF, you can grab the ID from the `browser.window.url` property from the `BrowserDetails` model in the database via the REST API.

![image](https://user-images.githubusercontent.com/434827/229420270-5ea8265a-f91a-42ad-b081-8b50a1c6146f.png)

