### PR TITLE
Scripts: Remove CDE Rake task and generate-certificate script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,15 +88,6 @@ namespace :rdoc do
   end
 end
 
-
-################################
-# Install
-
-#task :install do
-#  sh "export BEEF_TEST=true"
-#end
-
-
 ################################
 # X11 set up
 
@@ -216,43 +207,6 @@ task :dmg do
   puts "\nBeEF.dmg created\n"
 end
 
-
-################################
-# Create CDE Package
-# This will download and make the CDE Executable and
-# gnereate a CDE Package in cde-package
-
-task :cde do
-  puts "\nCloning and Making CDE...";
-  sh "git clone git://github.com/pgbovine/CDE.git";
-  Dir.chdir "CDE";
-  sh "make";
-  Dir.chdir "..";
-  puts "\nCreating CDE Package...\n";
-  sh "bundle install"
-  Rake::Task['cde_beef_start'].invoke
-  Rake::Task['beef_stop'].invoke
-  puts "\nCleaning Up...\n";
-  sleep (2);
-  sh "rm -rf CDE";
-  puts "\nCDE Package Created...\n";
-end
-
-################################
-# CDE/BeEF environment set up
-
-@beef_process_id = nil;
-
-task :cde_beef_start => 'beef' do
-  printf "Starting CDE BeEF (wait 10 seconds)..."
-  @beef_process_id = IO.popen("./CDE/cde ruby beef -x 2> /dev/null", "w+")
-  delays = [2, 2, 1, 1, 1, 0.5, 0.5, 0.5, 0.3, 0.2, 0.1, 0.1, 0.1, 0.05, 0.05]
-  delays.each do |i| # delay for 10 seconds
-    printf '.'
-    sleep (i)
-  end
-  puts '.'
-end
 
 ################################
 # ActiveRecord

--- a/generate-certificate
+++ b/generate-certificate
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-openssl req -new -newkey rsa:3072 -sha256 -x509 -days 3650 -nodes -out beef_cert.pem -keyout beef_key.pem -subj "/CN=localhost"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
-git checkout -b "release/$2"
+if [[ -z "${1}" || -z "${2}" ]]; then
+  echo "Error: missing arguments"
+  exit 1
+fi
+
+echo "Updating version ${1} to ${2}"
+
+git checkout -b "release/${2}"
 sed -i '' -e "s/$1/$2/g" VERSION
 sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package.json
 sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package-lock.json
 sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" config.yaml
 
-if [[ "$1" != *"-pre"* ]]; then
-	sed -i '' -e "s/v$1/v$2/g" .github/ISSUE_TEMPLATE.md
-fi
-
 git add VERSION package.json package-lock.json config.yaml
-git commit -m "Version bump $2"
-git push --set-upstream origin release/$2
+git commit -m "Version bump ${2}"
+git push --set-upstream origin "release/${2}"
 git push


### PR DESCRIPTION
The `generate-certificate` script is not required as certificate generation is performed by Rake tasks:

```
# rake -T | grep cert
rake ssl:create                 # Create a new SSL certificate
rake ssl:replace                # Re-generate SSL certificate
```

Unfortunately users will need to install test dependencies to run Rake tasks via Rake. I don't care.
