### PR TITLE
Fix cli

### DIFF
--- a/beef
+++ b/beef
@@ -39,6 +39,16 @@ $root_dir = File.join(File.expand_path(File.dirname(File.realpath(__FILE__))), '
 $:.unshift($root_dir)
 $home_dir = File.expand_path("#{Dir.home}/.beef/", __FILE__).freeze
 
+
+#
+# @note Parse beef command line arguments before requiring loader.
+# The loader will require bundler default arguments, bringing in Sinatra which will
+# then hog the Option Parsing. Thus, we need to parse before that.
+#
+require 'core/main/console/commandline'
+BeEF::Core::Console::CommandLine.parse
+
+
 #
 # @note Require core loader
 #
@@ -48,8 +58,8 @@ require 'timeout'
 #
 # @note Ask user if they would like to update beef
 #
-if File.exist?("#{$root_dir}git") && BeEF::Core::Console::CommandLine.parse[:update_disabled] == false
-  if BeEF::Core::Console::CommandLine.parse[:update_auto] == true
+if File.exist?("#{$root_dir}git") && BeEF::Core::Console::CommandLine.get_options[:update_disabled] == false
+  if BeEF::Core::Console::CommandLine.get_options[:update_auto] == true
     print 'Checking latest BeEF repository and updating'
     `git pull && bundle`
   elsif `git rev-parse master` != `git rev-parse origin/master`
@@ -79,10 +89,10 @@ end
 #
 # @note Initialize the Configuration object. Loads a different config.yaml if -c flag was passed.
 #
-if BeEF::Core::Console::CommandLine.parse[:ext_config].empty?
+if BeEF::Core::Console::CommandLine.get_options[:ext_config].empty?
   config = BeEF::Core::Configuration.new("#{$root_dir}/config.yaml")
 else
-  config = BeEF::Core::Configuration.new("#{BeEF::Core::Console::CommandLine.parse[:ext_config]}")
+  config = BeEF::Core::Configuration.new("#{BeEF::Core::Console::CommandLine.get_options[:ext_config]}")
 end
 
 #
@@ -105,12 +115,12 @@ end
 #
 # @note Check if port and WebSocket port need to be updated from command line parameters
 #
-unless BeEF::Core::Console::CommandLine.parse[:port].empty?
-  config.set('beef.http.port', BeEF::Core::Console::CommandLine.parse[:port])
+unless BeEF::Core::Console::CommandLine.get_options[:port].empty?
+  config.set('beef.http.port', BeEF::Core::Console::CommandLine.get_options[:port])
 end
 
-unless BeEF::Core::Console::CommandLine.parse[:ws_port].empty?
-  config.set('beef.http.websocket.port', BeEF::Core::Console::CommandLine.parse[:ws_port])
+unless BeEF::Core::Console::CommandLine.get_options[:ws_port].empty?
+  config.set('beef.http.websocket.port', BeEF::Core::Console::CommandLine.get_options[:ws_port])
 end
 
 #
@@ -150,7 +160,7 @@ require 'core/bootstrap'
 #
 # @note Prints the BeEF ascii art if the -a flag was passed
 #
-if BeEF::Core::Console::CommandLine.parse[:ascii_art] == true
+if BeEF::Core::Console::CommandLine.get_options[:ascii_art] == true
   BeEF::Core::Console::Banners.print_ascii_art
 end
 
@@ -182,7 +192,7 @@ Socket.do_not_reverse_lookup = true
 #
 db_file = config.get('beef.database.file')
 # @note Resets the database if the -x flag was passed
-if BeEF::Core::Console::CommandLine.parse[:resetdb]
+if BeEF::Core::Console::CommandLine.get_options[:resetdb]
   print_info 'Resetting the database for BeEF.'
   begin
     File.delete(db_file) if File.exist?(db_file)

--- a/core/main/console/commandline.rb
+++ b/core/main/console/commandline.rb
@@ -68,18 +68,15 @@ module BeEF
 
             opts.on("-h", "--help", "Prints this help") do
               puts opts
-              # NOTE:
-              # Dont exit here. Beef is also a Sinatra app and that comes with its own options.
-              # Therefore, we just fall through and hand over parsing to Sinatra afterwards.
-              puts("\nSinatra webapp options:")
+              exit 0
             end
           end
 
           # NOTE:
-          # Since OptionParser consumes ARGV, all options would be removed from it after parsing
-          # Sinatra would not receive anything anymore. To avoid that, we parse on a copy.
-          args_copy = ARGV.dup
-          optparse.parse!(args_copy)
+          # OptionParser consumes ARGV, all options are removed from it after parsing.
+          # If we wanted to pass Options to Sinatra, we would need to parse on a copy here.
+          # We don't do that since we explicitly don't want to allow users messing with these options, though.
+          optparse.parse!
           @already_parsed = true
         rescue OptionParser::InvalidOption
           puts 'Provided option not recognized by beef. If you provided a Sinatra option, note that beef explicitly disallows them.'

--- a/core/main/console/commandline.rb
+++ b/core/main/console/commandline.rb
@@ -85,10 +85,11 @@ module BeEF
         end
 
         #
-        # Return the parsed options
+        # Return the parsed options.
+        # Ensures that cmd line arguments are parsed.
         #
         def self.get_options
-          raise 'Must parse options before retrieving them. Call CommandLine.parse' unless @already_parsed
+          self.class.parse unless @already_parsed
           return @options 
         end
 

--- a/core/main/console/commandline.rb
+++ b/core/main/console/commandline.rb
@@ -88,7 +88,7 @@ module BeEF
         # Ensures that cmd line arguments are parsed.
         #
         def self.get_options
-          self.class.parse unless @already_parsed
+          parse unless @already_parsed
           return @options 
         end
 

--- a/core/main/console/commandline.rb
+++ b/core/main/console/commandline.rb
@@ -31,6 +31,8 @@ module BeEF
         # It also populates the 'options' hash.
         #
         def self.parse
+          return if @already_parsed
+
           optparse = OptionParser.new do |opts|
             opts.on('-x', '--reset', 'Reset the database') do
               @options[:resetdb] = true
@@ -80,8 +82,8 @@ module BeEF
           optparse.parse!(args_copy)
           @already_parsed = true
         rescue OptionParser::InvalidOption
-          puts 'Provided option not recognized by beef. If you provided a Sinatra option, you may ignore this warning. Run beef --help for more information.'
-          @already_parsed = true
+          puts 'Provided option not recognized by beef. If you provided a Sinatra option, note that beef explicitly disallows them.'
+          exit 1
         end
 
         #

--- a/core/ruby/print.rb
+++ b/core/ruby/print.rb
@@ -36,7 +36,7 @@ end
 # @note This function will only print messages if the debug flag is set to true
 def print_debug(s)
   config = BeEF::Core::Configuration.instance
-  return unless config.get('beef.debug') || BeEF::Core::Console::CommandLine.parse[:verbose]
+  return unless config.get('beef.debug') || BeEF::Core::Console::CommandLine.get_options[:verbose]
 
   puts Time.now.localtime.strftime('[%k:%M:%S]') + '[>]' + ' ' + s.to_s
   BeEF.logger.debug s.to_s

--- a/extensions/metasploit/api.rb
+++ b/extensions/metasploit/api.rb
@@ -28,7 +28,7 @@ module BeEF
 
             msf_module_config = {}
             path = "#{$root_dir}/#{BeEF::Core::Configuration.instance.get('beef.extension.metasploit.path')}/msf-exploits.cache"
-            if !BeEF::Core::Console::CommandLine.parse[:resetdb] && File.exist?(path)
+            if !BeEF::Core::Console::CommandLine.get_options[:resetdb] && File.exist?(path)
               print_debug 'Attempting to use Metasploit exploits cache file'
               raw = File.read(path)
               begin

--- a/spec/beef/api/auth_rate_spec.rb
+++ b/spec/beef/api/auth_rate_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'BeEF API Rate Limit' do
 		print_info "Loading database"
 		db_file = @config.get('beef.database.file')
 
-		if BeEF::Core::Console::CommandLine.parse[:resetdb]
+		if BeEF::Core::Console::CommandLine.get_options[:resetdb]
 			print_info 'Resetting the database for BeEF.'
 			File.delete(db_file) if File.exist?(db_file)
 		end


### PR DESCRIPTION
(Starting with) fixing beef cli option handling. Fixes #2174 
I still consider this WIP because I am not very well acquainted with ruby. Let me know if you find any issues or things to improve.

## Category
Core Functionality

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Beef options were not part of the `--help` before and not clearly communicated.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** The problem seems to pertain to Sinatra. Since some extensions use Sinatra, it is required from `loader.rb` (by requiring the bundle defaults). From then on, Sinatra basically hogs the command line parsing, parsing `--help`and then exiting.

After discussion I decided to simply shadow the Sinatra CLI handling. The changes consume the CLI args, Sinatra is left with nothing.

## Result

With these changes, we would at least see all the command line options being printed when running `./beef --help`, i.e.

```bash
Usage: beef [options]
    -x, --reset                      Reset the database
    -v, --verbose                    Display debug information
    -a, --ascii-art                  Prints BeEF ascii art
    -c, --config FILE                Specify configuration file to load (instead of ./config.yaml)
    -p, --port PORT                  Change the default BeEF listening port
    -w, --wsport WS_PORT             Change the default BeEF WebSocket listening port
        --update-disable             Skips update
        --update-auto                Automatic update with no prompt
    -h, --help                       Prints this help
```
