### PR TITLE
Update default tor address to a v3 address.

### DIFF
--- a/modules/network/detect_tor/module.rb
+++ b/modules/network/detect_tor/module.rb
@@ -6,7 +6,7 @@
 class Detect_tor < BeEF::Core::Command
   def self.options
     [
-      { 'name' => 'tor_resource', 'ui_label' => 'What Tor resource to request', 'value' => 'http://xycpusearchon2mc.onion/deeplogo.jpg' },
+      { 'name' => 'tor_resource', 'ui_label' => 'What Tor resource to request', 'value' => 'http://pzhdfe7jraknpj2qgu5cz2u3i4deuyfwmonvzu5i3nyw4t4bmg7o5pad.onion/static/images/logo.png' },
       { 'name' => 'timeout', 'ui_label' => 'Detection timeout', 'value' => '10000' }
     ]
   end


### PR DESCRIPTION
Updated default tor address to a V3 onion address: http://pzhdfe7jraknpj2qgu5cz2u3i4deuyfwmonvzu5i3nyw4t4bmg7o5pad.onion/static/images/logo.png

# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Modules

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** The default Tor address (http://xycpusearchon2mc.onion/deeplogo.jpg) in modules/network/detect_tor/module.rb is not a Tor v3 address and will not resolve even if a hooked browser is using Tor. 

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** The default Tor address has been changed to http://pzhdfe7jraknpj2qgu5cz2u3i4deuyfwmonvzu5i3nyw4t4bmg7o5pad.onion/static/images/logo.png. This is a resource from Tor's blog and is unlikely to change.


## Result

Tested on latest Tor browser: 12.0.6 (based on Mozilla Firefox 102.11.0esr) (64-bit)

Using http://xycpusearchon2mc.onion/deeplogo.jpg:

![beef1](https://github.com/beefproject/beef/assets/65378624/0d2995d6-7cfd-4cfe-aa9c-1bca47737ef6)

Using the updated Tor V3 address:

![beef2](https://github.com/beefproject/beef/assets/65378624/dda6eb01-945e-45bf-9d0d-9b8ecbc2b17c)
