### PR TITLE
Add ntfy extension

### DIFF
--- a/extensions/notifications/channels/ntfy.rb
+++ b/extensions/notifications/channels/ntfy.rb
@@ -1,0 +1,44 @@
+require 'net/http'
+require 'uri'
+
+module BeEF
+  module Extension
+    module Notifications
+      module Channels
+        class Ntfy
+
+          # Constructor
+          def initialize(message)
+            @config = BeEF::Core::Configuration.instance
+
+            # Endpoint URL
+            uri = URI.parse(@config.get('beef.extension.notifications.ntfy.endpoint_url'))
+
+            # Create client
+            http = Net::HTTP.new(uri.host, uri.port)
+
+            # Create Request
+            req = Net::HTTP::Post.new(uri.path)
+
+            # Add authentication if configured
+            if @config.get('beef.extension.notifications.ntfy.username') || @config.get('beef.extension.notifications.ntfy.password')
+              req.basic_auth @config.get('beef.extension.notifications.ntfy.username'), @config.get('beef.extension.notifications.ntfy.password')
+            end
+
+            # Set headers and body
+            req.content_type = 'text/plain'
+            req['Title'] = 'BeEF Notification'
+            req.body = message
+
+            # Use SSL if the URI scheme is 'https'
+            http.use_ssl = (uri.scheme == 'https')
+
+            # Send request
+            http.request(req)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/extensions/notifications/config.yaml
+++ b/extensions/notifications/config.yaml
@@ -26,3 +26,9 @@ beef:
               webhook_url: "your_webhook_url"
               channel: "#beef"     # Slack channel
               username: "notifier" # Username can be anything
+            ntfy:
+              enable: false
+              endpoint_url: "https://ntfy.sh/beef"
+              username: "" # Leave blank if not needed
+              password: "" # Leave blank if not needed
+

--- a/extensions/notifications/notifications.rb
+++ b/extensions/notifications/notifications.rb
@@ -7,6 +7,8 @@
 require 'extensions/notifications/channels/email'
 require 'extensions/notifications/channels/pushover'
 require 'extensions/notifications/channels/slack_workspace'
+require 'extensions/notifications/channels/ntfy'
+
 
 module BeEF
   module Extension
@@ -34,6 +36,9 @@ module BeEF
           BeEF::Extension::Notifications::Channels::Pushover.new(message) if @config.get('beef.extension.notifications.pushover.enable') == true
 
           BeEF::Extension::Notifications::Channels::SlackWorkspace.new(message) if @config.get('beef.extension.notifications.slack.enable') == true
+
+          BeEF::Extension::Notifications::Channels::Ntfy.new(message) if @config.get('beef.extension.notifications.ntfy.enable') == true
+
         end
       end
     end


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
 Extension

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Adds the option to use ntfy as a notifier

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** 
I added the following:

**New Module**: Introduced a new notification module under `BeEF::Extension::Notifications::Channels` named **Ntfy**. This module allows BeEF to send notifications through the ntfy platform.

**URI Parsing**: Utilized the URI library to accurately parse the endpoint URL configured in the settings.

**HTTP Basic Authentication**: Implemented HTTP Basic Authentication support for the ntfy endpoint. The username and password are fetched from the configuration and, if present, are used to set the appropriate authentication headers for the HTTP request.

**Notification Sending**: Constructed an HTTP POST request using Net::HTTP::Post. Set the request's content type to 'text/plain' and included a title header 'BeEF Notification'. The body of the request contains the message to be sent to the ntfy platform.

**SSL Support**: Added a check to determine if the provided ntfy endpoint uses HTTPS. If it does, the SSL option for the HTTP client (Net::HTTP) is enabled to ensure secure communication.

**Configuration Integration**: Integrated the new ntfy functionality with the BeEF configuration system. This allows users to specify the ntfy endpoint URL, as well as optional authentication credentials, in the BeEF configuration file.


## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** It ran good using the `docker build` and in a debian local environment with ./install script

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*

include the following config into the example for the extensions yaml
```yaml
            ntfy:
              enable: false
              endpoint_url: "https://ntfy.sh/beef"
              username: "" # Leave blank if not needed
              password: "" # Leave blank if not needed
```
