### PR TITLE
Added install section for almalinux

### DIFF
--- a/install
+++ b/install
@@ -123,6 +123,7 @@ install_linux() {
 			if [ "$answer_alma_ruby" == "y" ] || [ "$answer_alma_ruby" == "Y" ]; then
 				dnf module reset ruby -y
 				dnf module enable ruby:3.1 -y
+				dnf install -y ruby
 			fi
 		else dnf config-manager --set-enabled powertools
 			dnf groupinstall "Development Tools" -y
@@ -131,9 +132,10 @@ install_linux() {
 			if [ "$answer_alma_ruby" == "y" ] || [ "$answer_alma_ruby" == "Y" ]; then
     				dnf module reset ruby -y
 				dnf module enable ruby:3.0 -y
+				dnf install -y ruby
 			fi
 		fi
-		sudo yum install -y ruby ruby-devel git make gcc openssl-devel gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs
+		sudo yum install -y ruby-devel git make gcc openssl-devel gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs
 		gem install bundler
 
 

--- a/install
+++ b/install
@@ -78,6 +78,8 @@ install_linux() {
 	Distro=''
 	if [ -f /etc/blackPanther-release ]; then
 		Distro='blackPanther'
+	elif [ -f /etc/almalinux-release ]; then
+		Distro='Alma'
 	elif [ -f /etc/redhat-release ]; then
 		Distro='RedHat'
 	elif [ -f /etc/debian_version ]; then
@@ -111,6 +113,30 @@ install_linux() {
 			info "No Ruby package manager detected - will install Ruby"
 			sudo apt-get install ruby-dev
 		fi
+
+	elif [ "${Distro}" = "Alma" ]; then
+		sudo dnf install -y dnf-plugins-core
+		if grep -q "AlmaLinux release 9" /etc/almalinux-release ; then 
+			dnf config-manager --set-enabled crb
+			echo "Do you need to install a fresh version of ruby? (y/n)"
+			read answer_alma_ruby
+			if [ "$answer_alma_ruby" == "y" ] || [ "$answer_alma_ruby" == "Y" ]; then
+				dnf module reset ruby -y
+				dnf module enable ruby:3.1 -y
+			fi
+		else dnf config-manager --set-enabled powertools
+			dnf groupinstall "Development Tools" -y
+			echo "Do you need to install a fresh version of ruby? (y/n)"
+			read answer_alma_ruby
+			if [ "$answer_alma_ruby" == "y" ] || [ "$answer_alma_ruby" == "Y" ]; then
+    				dnf module reset ruby -y
+				dnf module enable ruby:3.0 -y
+			fi
+		fi
+		sudo yum install -y ruby ruby-devel git make gcc openssl-devel gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs
+		gem install bundler
+
+
 	elif [ "${Distro}" = "RedHat" ]; then
 		sudo yum install -y git make gcc openssl-devel gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel bzip2 autoconf automake libtool bison sqlite-devel nodejs
 	elif [ "${Distro}" = "SuSE" ]; then


### PR DESCRIPTION
# Pull Request


## Category
*Install bash script

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Added a section for alma linux installs

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** During install on Alma, i was getting assigned to redhat-release and installation was failing.

Added: first, almalinux-release is detected before redhat, we then check if alma is version 9, and if so install crb, otherwise we install powertools (and development tools to fix an issue with ruby dependencies later on during the install)
We read from the user if they want to install ruby, and automatically do a module reset and install if they want it.
additionally, we install the ruby-devel package.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** I have tested this on fresh alma EL8 and EL9 minimal machines, both are now working as intended when ran from the install script.

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
The user no longer needs to install ruby manually from alma 8/9 (dependant on the dnf module versions not changing)

##Additional info
This is my first contribution to open source, if there is anything I can do better, please do let me know.
Much appreciated.
