### PR TITLE
Update Ruby Version - Complete

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -23,7 +23,7 @@ Prerequisites
 
 BeEF requires Ruby 3.0+.
 
-If your operating system package manager does not support Ruby version 2.7,
+If your operating system package manager does not support Ruby version 3.0,
 you can add the brightbox ppa repository for the latest version of Ruby:
 
   $ sudo apt-add-repository -y ppa:brightbox/ruby-ng

--- a/beef
+++ b/beef
@@ -12,7 +12,7 @@
 $VERBOSE = nil
 
 #
-# @note Version check to ensure BeEF is running Ruby 2.7+
+# @note Version check to ensure BeEF is running Ruby 3.0+
 #
 min_ruby_version = '3.0'
 if RUBY_VERSION < min_ruby_version


### PR DESCRIPTION
# Documentation Update
Confirmed Development is Alive: [REF #2982](https://github.com/beefproject/beef/pull/2982) `Update README.md "Ruby Version 3.0+"`

As per:
https://github.com/beefproject/beef/blob/554d42b2c61e5e296d89a50f607031131a56a007/install#L186

Documents behind:
https://github.com/beefproject/beef/blob/554d42b2c61e5e296d89a50f607031131a56a007/INSTALL.txt#L24-L26

https://github.com/beefproject/beef/blob/554d42b2c61e5e296d89a50f607031131a56a007/beef#L15-L17

GitHub Pages deployment seems to be stuck on 2.5?

![image](https://github.com/beefproject/beef/assets/53882381/8b1eb42f-4b7f-4747-a2e2-7d89652b8eac)
https://beefproject.github.io/beef/