### PR TITLE
Added 'mini_portile2'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@
 
 gem 'net-smtp', require: false
 gem 'json'
+gem 'mini_portile2'
 
 gem 'eventmachine', '~> 1.2', '>= 1.2.7'
 gem 'thin', '~> 1.8'


### PR DESCRIPTION
Added `gem 'mini_portile2'` because it is needed for `nokogiri`. Tested on NixOS by using `bundle install` and `bundix` to generate `gemset.nix` and build Beef on Nix. This change prevents error by nokogiri.

# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
*e.g. Bug, Module, Extension, Core Functionality, Documentation, Tests*

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:**

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:**

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:**

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
