### PR TITLE
Fix Install breaking - Apply more strict rules for activerecord version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'term-ansicolor', :require => 'term/ansicolor'
 gem 'rubyzip', '~> 2.3'
 gem 'espeak-ruby', '~> 1.1.0' # Text-to-Voice
 gem 'rake', '~> 13.2'
-gem 'activerecord', '~> 7.0' 
+gem 'activerecord', '7.1.4.2' 
 gem 'otr-activerecord', '~> 2.4.0'
 gem 'sqlite3', '~> 1.4'
 gem 'rubocop', '~> 1.68.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.16.7-arm-linux)
@@ -126,7 +126,7 @@ GEM
       hashie-forbidden_attributes (~> 0.1)
     parallel (1.26.3)
     parseconfig (1.1.2)
-    parser (3.3.5.0)
+    parser (3.3.5.1)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.4)
@@ -168,7 +168,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.1)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -241,7 +241,7 @@ GEM
     tilt (2.4.0)
     timeout (0.4.1)
     timers (4.3.5)
-    tins (1.35.0)
+    tins (1.37.0)
       bigdecimal
       sync
     tzinfo (2.0.6)
@@ -268,7 +268,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activerecord (~> 7.0)
+  activerecord (= 7.1.4.2)
   ansi (~> 1.5)
   async (~> 1.32)
   async-dns (~> 1.3)


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Bug

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** At this stage beef works with activerecord up to version 7.1.4.2. However, command in Gemfile didn't enforce that and would allow for installation of the latest minor version, which is 7.2.1.2. This happens when person runs ./install.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** Added strict rule into Gemfile to install the 7.1.4.2 version not to break the installation. As part of dependabot suggested upgrade will analyse the differences in 7.2.1.2 and get them installed in controlled and tested way.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** bundle exec rake, running framework and debug modules through FF browser. Also, the Browserstack testing will run as part of this PR check.

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
