### PR TITLE
Fix proxy extension

### DIFF
--- a/extensions/proxy/proxy.rb
+++ b/extensions/proxy/proxy.rb
@@ -67,7 +67,7 @@ module BeEF
               break if line.strip.empty?
             end
             socket.puts("HTTP/1.0 200 Connection established\r\n\r\n")
-            socket = OpenSSL::SSL::SSLSocket(socket, @ssl_context)
+            socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
             socket.accept
             print_debug("[PROXY] Handled CONNECT to #{host_port}")
             request_line = socket.readline


### PR DESCRIPTION
## Category
Bug fix

## Feature/Issue Description
Issue described here: https://github.com/beefproject/beef/issues/3219

## Test Cases
Launch beef on 127.0.0.1 port 3000, hook a browser on 127.0.0.1 (tested on firefox linux), right click browser and select "Use as proxy" now run: `http_proxy=http://127.0.0.1:6789 curl http://127.0.0.1:3000/`

To test https proxying first run:
`openssl s_server -key beef_key.pem -cert beef_cert.pem -accept 4433 -www`
Then
`http_proxy=http://127.0.0.1:6789 curl -k https://127.0.0.1:4433/`

(Note if you get `Unsupported response code in HTTP response` your browser is likely hooked to localhost and you try to access 127.0.0.1 in such cases the proxy returns 
```
HTTP/1.1 -1

ERROR: Cross Domain Request. The request was sent however it is impossible to view the response.
```
Which we might want to fix to be visible in curl by using proper status codes and error messages.)

Both return expected website data.

# Rake results:
```
bundle exec rake
...
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) BeEF Extension Social Engineering when wget exists clone web page
     # Temporarily skipped with xit
     # ./spec/beef/extensions/social_engineering_spec.rb:22

  2) BeEF Extension WebSockets confirms that a websocket client can connect to the BeEF Websocket Server
     # Temporarily skipped with xit
     # ./spec/beef/extensions/websocket_spec.rb:35

  3) BeEF Extension Requester requester works
     # Temporarily skipped with xit
     # ./spec/beef/extensions/requester_spec.rb:25


Finished in 2.33 seconds (files took 1.11 seconds to load)
131 examples, 0 failures, 3 pending
```


# Technical issue and solution
The previous version relied on the fact that ruby allowed reading raw data from the SSLSocket before the handshake. This was used to initialize the proxy in plain text and then only perform a ssl/tls handshake if a CONNECT method was used by the client. (note socket.accept for a SSLSocket means "perform ssl/tls handshake").

This does not work anymore so instead we use a regular TCP server up until the point where SSLSocket is actually needed.