### PR TITLE
Fixes issue/host-name-validation (#3091)

### DIFF
--- a/core/main/router/router.rb
+++ b/core/main/router/router.rb
@@ -14,6 +14,19 @@ module BeEF
 
         configure do
           set :show_exceptions, false
+
+          # Configure Rack::Protection::HostAuthorization.
+          # Allow Rack development defaults and dynamically permit the public host
+          # defined by beef.http.public.host to prevent "Host not permitted" errors.
+          permitted = [
+            '.localhost',
+            '.test',
+            IPAddr.new('0.0.0.0/0'),
+            IPAddr.new('::/0')
+          ]
+          public_host = config.get('beef.http.public.host').to_s.strip
+          permitted << public_host unless public_host.empty?
+          set :host_authorization, { permitted_hosts: permitted }
         end
 
         # @note Override default 404 HTTP response


### PR DESCRIPTION
# Pull Request

## Category
*Bug, Documentation*

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:**
This PR fixes an inconsistency in host name validation when a custom domain is configured via beef.http.public.host.
Previously, requests to the Admin UI succeeded, while requests to other endpoints were rejected with 403 (Host not permitted). This change ensures that the configured public host is consistently permitted across all endpoints.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:**
Issue
When a custom domain is set in beef.http.public.host, the following inconsistent behaviour occurs:
- https://my-domain.com:3000/ui/... → accessible
- https://my-domain.com:3000/hook.js → 403 (Host not permitted)

Root Cause
Host name validation is performed at different layers depending on the endpoint:
- Admin UI requests bypass Rack’s HostAuthorization middleware and reach the BeEF application layer directly. As a result, they are not affected by Sinatra’s permitted_hosts restrictions. (See: extensions/admin_ui/handlers/ui.rb)
- Other endpoints such as hook.js are subject to Rack’s HostAuthorization middleware, where the Host header is validated.
If the host is not included in permitted_hosts, the request is rejected with 403 (Host not permitted).

In November 2024, Sinatra introduced stricter host validation as part of a [security fix](https://github.com/sinatra/sinatra/pull/2053). Since that change, the default permitted_hosts in the development environment are limited to:
- .localhost
- .test
- IPv4 / IPv6 addresses

Therefore, even if a custom domain is configured in beef.http.public.host, requests are rejected unless that domain is explicitly added to permitted_hosts.

Solution
This PR updates core/main/router/router.rb to automatically add the value of beef.http.public.host to permitted_hosts.
This aligns host validation behaviour across all endpoints and removes the inconsistency between the Admin UI and other resources such as hook.js.

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:**
Test Setup
1. Add a custom domain to /etc/hosts:
```
127.0.0.1 my-domain.com
```
2. Configure config.yaml:
```
beef:
  http:
    public:
      host: "my-domain.com"
      port: "3000"
      https: true
``` 

Test Matrix
The following configurations were tested, confirming that Admin UI, hook.js, and the demo page are all accessible:
a. beef.http.public configured / http.https.enable: true
b. beef.http.public configured / http.https.enable: false
c. beef.http.public not configured / http.https.enable: true
d. beef.http.public not configured / http.https.enable: false

## Wiki Page
Added instructions for HTTPS configuration.
https://github.com/beefproject/beef/wiki/Configuration#https-configuration
https://github.com/beefproject/beef/wiki/Docker-Setup#https-configuration