### PR TITLE
Bump lodash in the npm_and_yarn group across 1 directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -660,10 +660,11 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the / directory: [lodash](https://github.com/lodash/lodash).


Updates `lodash` from 4.17.21 to 4.17.23
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.21...4.17.23)

---
updated-dependencies:
- dependency-name: lodash dependency-version: 4.17.23 dependency-type: indirect dependency-group: npm_and_yarn ...

# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
*e.g. Bug, Module, Extension, Core Functionality, Documentation, Tests*

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:**

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:**

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:**

## Wiki Page
*If you are adding a new feature that is not easily understood without context, please draft a section to be added to the Wiki below.*
