### PR TITLE
Fix script issues

### DIFF
--- a/install
+++ b/install
@@ -138,8 +138,8 @@ install_linux() {
 			sudo pacman -S ruby ruby-rdoc
 		fi
 	elif [ "${Distro}" = "Alpine" ]; then
-		apk update
-		apk add curl git build-base openssl readline-dev zlib zlib-dev libressl-dev yaml-dev sqlite-dev sqlite libxml2-dev libxslt-dev autoconf libc6-compat ncurses5 automake libtool bison nodejs
+		sudo apk update
+		sudo apk add curl git build-base openssl readline-dev zlib zlib-dev libressl-dev yaml-dev sqlite-dev sqlite libxml2-dev libxslt-dev autoconf libc6-compat ncurses5 automake libtool bison nodejs
 	fi
 }
 

--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -13,10 +13,17 @@ fi
 echo "Updating version ${1} to ${2}"
 
 git checkout -b "release/${2}"
-sed -i '' -e "s/$1/$2/g" VERSION
-sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package.json
-sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package-lock.json
-sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" config.yaml
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' -e "s/$1/$2/g" VERSION
+  sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package.json
+  sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package-lock.json
+  sed -i '' -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" config.yaml
+else
+  sed -i -e "s/$1/$2/g" VERSION
+  sed -i -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package.json
+  sed -i -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" package-lock.json
+  sed -i -e "s/\"version\": \"$1\"/\"version\": \"$2\"/g" config.yaml
+fi
 
 git add VERSION package.json package-lock.json config.yaml
 git commit -m "Version bump ${2}"


### PR DESCRIPTION
# Pull Request

Thanks for submitting a PR! Please fill in this template where appropriate:

## Category
Bug, Tools, Installer

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** This PR fixes two cross-platform compatibility scripting bugs affecting installation and development tools on standard GNU/Linux environments: (1) a Linux syntax error in the version bumping utility caused by macOS-specific `sed -i` arguments, and (2) missing `sudo` privileges on the Alpine Linux installer path

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** 
1. tools/bump-version.sh: Implemented a check on the `$OSTYPE` environment variable. If running on macOS , the script utilizes the BSD-compliant `sed -i '' -e` syntax. On other operating systems (like GNU/Linux), it falls back to standard `sed -i -e` syntax.
2. install: Added `sudo` to the `apk update` and `apk add` commands on the Alpine Linux branch to ensure standard root privileges during dependency installation (aligning with the Debian, RedHat, SuSE, and Arch Linux installation paths).
3. Both files have been normalized to standard Unix `\n` (LF) line endings

## Test Cases
**Q:** Describe your test cases, what you have covered and if there are any use cases that still need addressing.
**A:** Both scripts were successfully validated for bash parsing and syntax correctness using the `bash -n` utility, completing with zero warnings or syntax errors

## Wiki Page
*(Not applicable)*
