### PR TITLE
Fix UnknownAttributeError on NetworkHost.create

### DIFF
--- a/modules/network/get_ntop_network_hosts/module.rb
+++ b/modules/network/get_ntop_network_hosts/module.rb
@@ -31,7 +31,7 @@ class Get_ntop_network_hosts < BeEF::Core::Command
     data.to_s.scan(/"hostNumIpAddress":"([\d.]+)"/).flatten.each do |ip|
       if BeEF::Filters.is_valid_ip?(ip)
         print_debug("Hooked browser found host #{ip}")
-        BeEF::Core::Models::NetworkHost.create(hooked_browser_id: session_id, ip: ip, port: port)
+        BeEF::Core::Models::NetworkHost.create(hooked_browser_id: session_id, ip: ip)
       end
     end
   end


### PR DESCRIPTION
# Pull Request

## Category
Bug

## Feature/Issue Description
**Q:** Please give a brief summary of your feature/fix
**A:** Fixes #3573. The `get_ntop_network_hosts` module crashed when saving a
discovered network host, because it passed a `port:` value to
`NetworkHost.create` — but the `network_hosts` table has no `port` column. This
raised `ActiveModel::UnknownAttributeError` at runtime.

**Q:** Give a technical rundown of what you have changed (if applicable)
**A:** In `modules/network/get_ntop_network_hosts/module.rb`, the call on line 34
was passing an attribute that does not exist on the model:

```ruby
# Before
BeEF::Core::Models::NetworkHost.create(hooked_browser_id: session_id, ip: ip, port: port)
# After
BeEF::Core::Models::NetworkHost.create(hooked_browser_id: session_id, ip: ip)
